### PR TITLE
Minor fixes to the patient search page

### DIFF
--- a/src/patient-search/patient-search.component.tsx
+++ b/src/patient-search/patient-search.component.tsx
@@ -109,33 +109,31 @@ function PatientSearch(props: PatientSearchProps) {
           autoFocus
         />
       </div>
-      <div className={styles.searchResults}>
-        {!isEmpty(searchResults) && (
-          <div>
-            <p>
-              <span className={styles.resultsText}>
-                Found {searchResults.length} patient{" "}
-                {searchResults.length === 1 ? "chart" : "charts"} containing
-              </span>
-            </p>
-            <p className={styles.searchTerm}>"{searchTerm}"</p>
-            <PatientSearchResults
-              match={props.match}
-              searchTerm={searchTerm}
-              patients={pagedResults}
+      {!isEmpty(searchResults) && (
+        <div className={styles.searchResults}>
+          <p>
+            <span className={styles.resultsText}>
+              Found {searchResults.length} patient{" "}
+              {searchResults.length === 1 ? "chart" : "charts"} containing
+            </span>
+          </p>
+          <p className={styles.searchTerm}>"{searchTerm}"</p>
+          <PatientSearchResults
+            match={props.match}
+            searchTerm={searchTerm}
+            patients={pagedResults}
+          />
+          <div className={styles.pagination}>
+            <PaginationNav
+              itemsShown={resultsPerPage}
+              totalItems={totalPages}
+              onChange={handlePageChange}
             />
-            <div className={styles.pagination}>
-              <PaginationNav
-                itemsShown={resultsPerPage}
-                totalItems={totalPages}
-                onChange={handlePageChange}
-              />
-            </div>
           </div>
-        )}
-      </div>
+        </div>
+      )}
       {isEmpty(searchResults) && !emptyResult && (
-        <Tile light style={{ textAlign: "center" }}>
+        <Tile style={{ textAlign: "center" }}>
           <p className={styles.actionText}>
             <span>
               Search by <b>patient number</b>
@@ -151,7 +149,7 @@ function PatientSearch(props: PatientSearchProps) {
             <span className={styles.resultsText}>Search results for:</span>
           </p>
           <p className={styles.searchTerm}>"{searchTerm}"</p>
-          <Tile light style={{ textAlign: "center" }}>
+          <Tile style={{ textAlign: "center" }}>
             <EmptyDataIllustration />
             <p className={styles.emptyResultText}>
               Sorry, no patient charts have been found


### PR DESCRIPTION
- The div containing the search results following a successful search is now wrapped in conditional logic so that the styles set on it only show when the condition is truthy, i.e. when the search successfully returns results. This fixes the weird margin under the patient search input (before and after ⬇️ )

![Screenshot 2021-02-01 at 09 39 12](https://user-images.githubusercontent.com/8509731/106424410-2fbf1280-6473-11eb-9e9e-c7e502bede26.png)

![Screenshot 2021-02-01 at 09 39 31](https://user-images.githubusercontent.com/8509731/106424433-39487a80-6473-11eb-907a-a0263c564ba5.png)

- Sets the color of the empty search results tile to the default gray. Previously it was set to white using the light modifier prop. It now matches the design spec. (before and after ⬇️ )

![Screenshot 2021-02-01 at 09 42 30](https://user-images.githubusercontent.com/8509731/106424462-45ccd300-6473-11eb-8a1a-6336bbf2495d.png)


![Screenshot 2021-02-01 at 09 45 46](https://user-images.githubusercontent.com/8509731/106424490-50876800-6473-11eb-9418-67af768fb206.png)

