### PR TITLE
Widget area expanded to full width

### DIFF
--- a/packages/esm-home-app/src/dashboard/home-dashboard.component.css
+++ b/packages/esm-home-app/src/dashboard/home-dashboard.component.css
@@ -92,4 +92,6 @@
 
 .widgetsArea {
   margin-top: 2rem;
+  padding: 0 1rem;
+  width: 100%;
 }


### PR DESCRIPTION
### What does this PR do?

I have expanded the widget area to the full width. The extension slot will now take the full width of the available space. The active visit widget now looks like:

![image](https://user-images.githubusercontent.com/51502471/125671175-ff9470a7-48f8-40e1-94ea-98a1ddcb823c.png)
