### PR TITLE
O3-939: External links to be shown in the app menu

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 dist/
 node_modules/
 **/*.css
+**/*.scss
 **/*.md
 **/*.json

--- a/packages/esm-home-app/src/index.ts
+++ b/packages/esm-home-app/src/index.ts
@@ -95,6 +95,14 @@ function setupOpenMRS() {
         online: true,
         offline: false,
       },
+      {
+        id: 'external-app-menu-links',
+        slot: 'app-menu-external-links-slot',
+        load: getAsyncLifecycle(() => import('./refapp-links/external-ref-links.component'), options),
+        // privelege: '',
+        online: true,
+        offline: true,
+      },
     ],
   };
 }

--- a/packages/esm-home-app/src/openmrs-esm-home-schema.ts
+++ b/packages/esm-home-app/src/openmrs-esm-home-schema.ts
@@ -41,4 +41,39 @@ export const esmHomeSchema = {
       _description: 'Whether to show widgets on the home page (including extensions)',
     },
   },
+  externalRefLinks: {
+    enabled: {
+      _type: Type.Boolean,
+      _default: true,
+      _description: 'Whether to show external links in the app menu',
+    },
+    links: {
+      _type: Type.Array,
+      _elements: {
+        title: {
+          _type: Type.String,
+          _description: 'Title of the link',
+        },
+        redirect: {
+          _type: Type.String,
+          _description: 'Link to redirect to',
+        },
+      },
+      _default: [
+        {
+          title: 'Pharmacy',
+          redirect: '${openmrsSpaBase}/pharmacy',
+        },
+        {
+          title: 'Laboratory',
+          redirect: '${openmrsSpaBase}/laboratory',
+        },
+        {
+          title: 'Analytics',
+          redirect: '${openmrsSpaBase}/analytics',
+        },
+      ],
+      _description: 'The links to be showcased in the app menu',
+    },
+  },
 };

--- a/packages/esm-home-app/src/openmrs-esm-home-schema.ts
+++ b/packages/esm-home-app/src/openmrs-esm-home-schema.ts
@@ -56,7 +56,7 @@ export const esmHomeSchema = {
         },
         redirect: {
           _type: Type.String,
-          _description: 'Link to redirect to',
+          _description: 'Link to redirect to (must be an external link)',
         },
       },
       _default: [

--- a/packages/esm-home-app/src/refapp-links/external-ref-links.component.tsx
+++ b/packages/esm-home-app/src/refapp-links/external-ref-links.component.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useConfig, ConfigurableLink } from '@openmrs/esm-framework';
 import styles from '../root.scss';
-import { ArrowUpRight16 } from '@carbon/icons-react';
+import { Launch16 } from '@carbon/icons-react';
 
 const ExternalRefLinks: React.FC<{}> = () => {
   const config = useConfig();
@@ -9,10 +9,10 @@ const ExternalRefLinks: React.FC<{}> = () => {
   return config?.externalRefLinks?.enabled ? (
     <div className={styles.externalLinks}>
       {config?.externalRefLinks?.links?.map((link) => (
-        <ConfigurableLink to={link?.redirect}>
+        <a target="_blank" href={link?.redirect}>
           {link?.title}
-          <ArrowUpRight16 className={styles.topRightArrow} />
-        </ConfigurableLink>
+          <Launch16 className={styles.launchIcon} />
+        </a>
       ))}
     </div>
   ) : null;

--- a/packages/esm-home-app/src/refapp-links/external-ref-links.component.tsx
+++ b/packages/esm-home-app/src/refapp-links/external-ref-links.component.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { useConfig, ConfigurableLink } from '@openmrs/esm-framework';
+import styles from '../root.scss';
+import { ArrowUpRight16 } from '@carbon/icons-react';
+
+const ExternalRefLinks: React.FC<{}> = () => {
+  const config = useConfig();
+
+  return config?.externalRefLinks?.enabled ? (
+    <div className={styles.externalLinks}>
+      {config?.externalRefLinks?.links?.map((link) => (
+        <ConfigurableLink to={link?.redirect}>
+          {link?.title}
+          <ArrowUpRight16 className={styles.topRightArrow} />
+        </ConfigurableLink>
+      ))}
+    </div>
+  ) : null;
+};
+
+export default ExternalRefLinks;

--- a/packages/esm-home-app/src/root.scss
+++ b/packages/esm-home-app/src/root.scss
@@ -1,1 +1,11 @@
 @import "carbon-components/scss/globals/scss/typography.scss";
+@import "~carbon-components/scss/globals/scss/_spacing.scss";
+@import '~@openmrs/esm-styleguide/src/vars';
+
+.externalLinks {
+  border-top: 1px solid $ui-01;
+}
+
+.topRightArrow {
+  margin-left: $spacing-03;
+}

--- a/packages/esm-home-app/src/root.scss
+++ b/packages/esm-home-app/src/root.scss
@@ -3,9 +3,9 @@
 @import '~@openmrs/esm-styleguide/src/vars';
 
 .externalLinks {
-  border-top: 1px solid $ui-01;
+  border-top: 1px solid $brand-teal-01;
 }
 
-.topRightArrow {
+.launchIcon {
   margin-left: $spacing-03;
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

I have added an option to enable/disable showing external links in the app menu and the user can add the links in the configuration via implementor tools, which will be visible in the app menu.


## Screenshots

![image](https://user-images.githubusercontent.com/51502471/142975785-461ad5a5-1f87-453e-9eda-0d40bd6f3f4f.png)
![image](https://user-images.githubusercontent.com/51502471/142975821-84865b09-3cc7-4d63-ae4e-e3165d8b94bd.png)


## Related Issue

https://issues.openmrs.org/browse/O3-939

## Other

Corresponding PR to add extension slot: https://github.com/openmrs/openmrs-esm-core/pull/226
<!--
Optional.
Anything else that isn't covered by one of the sections above.
-->
