### PR TITLE
O3-780: Add bundle size monitoring to PR actions

### DIFF
--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -1,0 +1,22 @@
+name: Report bundle size
+
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  file_size_impact:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Setup git
+        uses: actions/checkout@v2
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: "16.6.1"
+      - run: npx lerna bootstrap
+      - name: Report changes
+        run: node ./tools/size-reporter.mjs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@babel/preset-react": "^7.10.4",
     "@babel/preset-typescript": "^7.10.4",
     "@babel/runtime": "^7.12.13",
+    "@jsenv/file-size-impact": "^12.1.1",
     "@openmrs/esm-framework": "next",
     "@testing-library/dom": "^7.20.0",
     "@testing-library/jest-dom": "^5.11.0",

--- a/tools/size-generator.mjs
+++ b/tools/size-generator.mjs
@@ -1,0 +1,43 @@
+import { generateFileSizeReport } from '@jsenv/file-size-impact';
+import { promises } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const packagesDir = resolve(currentDir, '..', 'packages');
+const manifestConfig = {};
+const trackingConfig = {};
+
+async function setPackages() {
+  const names = await promises.readdir(packagesDir);
+
+  await Promise.all(
+    names.map(async (name) => {
+      const p = resolve(packagesDir, name);
+      const stat = await promises.stat(p);
+
+      if (stat.isDirectory()) {
+        const pj = resolve(p, 'package.json');
+        const content = await promises.readFile(pj, 'utf8');
+        const packageName = JSON.parse(content).name;
+        manifestConfig[`./packages/${name}/dist/*.buildmanifest.json`] = true;
+        trackingConfig[packageName] = {
+          [`./packages/${name}/dist/*.js`]: true,
+          [`./packages/${name}/dist/*.css`]: true,
+          [`./packages/${name}/dist/*.map`]: false,
+          [`./packages/${name}/dist/*.txt`]: false,
+          [`./packages/${name}/dist/*.json`]: false,
+        };
+      }
+    }),
+  );
+}
+
+await setPackages();
+
+export const fileSizeReport = await generateFileSizeReport({
+  log: process.argv.includes('--log'),
+  projectDirectoryUrl: new URL('../', import.meta.url),
+  manifestConfig,
+  trackingConfig,
+});

--- a/tools/size-reporter.mjs
+++ b/tools/size-reporter.mjs
@@ -1,0 +1,8 @@
+import { reportFileSizeImpact, readGitHubWorkflowEnv } from '@jsenv/file-size-impact';
+
+await reportFileSizeImpact({
+  ...readGitHubWorkflowEnv(),
+  buildCommand: 'npx lerna run build',
+  installCommand: 'npx lerna bootstrap',
+  fileSizeReportModulePath: './tools/size-generator.mjs#fileSizeReport',
+});


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

We should be tracking bundle size changes. We want a tool that comments on every PR with the bundle size change caused by the PR.

## Screenshots

*None.*

## Issue

[O3-780](https://issues.openmrs.org/browse/O3-780)

## Other

*None.*
