### PR TITLE
(chore)Husky fix: Replaced prepare with postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "extract-translations": "lerna run extract-translations -- --config ../../tools/i18next-parser.config.js",
     "coverage": "yarn test --coverage",
     "prettier": "prettier --config prettier.config.js --write \"packages/**/*.{ts,tsx}\"",
-    "prepare": "husky install",
+    "postinstall": "husky install",
     "start": "openmrs develop --sources 'packages/esm-*-app/'",
     "test": "cross-env TZ=UTC jest --config jest.config.json --verbose false --passWithNoTests",
     "verify": "turbo run lint && yarn test && turbo run typescript"
@@ -45,7 +45,7 @@
     "eslint-config-prettier": "^8.2.0",
     "eslint-config-ts-react-important-stuff": "^3.0.0",
     "eslint-plugin-prettier": "^4.2.1",
-    "husky": "^8.0.0",
+    "husky": "^8.0.1",
     "i18next": "^21.8.14",
     "i18next-parser": "^6.5.0",
     "identity-obj-proxy": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4025,7 +4025,7 @@ __metadata:
     eslint-config-prettier: ^8.2.0
     eslint-config-ts-react-important-stuff: ^3.0.0
     eslint-plugin-prettier: ^4.2.1
-    husky: ^8.0.0
+    husky: ^8.0.1
     i18next: ^21.8.14
     i18next-parser: ^6.5.0
     identity-obj-proxy: ^3.0.0
@@ -10400,7 +10400,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"husky@npm:^8.0.0":
+"husky@npm:^8.0.1":
   version: 8.0.1
   resolution: "husky@npm:8.0.1"
   bin:


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

According to the statement on the Husky website [here](https://typicode.github.io/husky/#/?id=install), it states that
```
Yarn 2+ doesn't support prepare lifecycle script, so husky needs to be installed differently (this doesn't apply to Yarn 1 though). See [Yarn 2+ install](https://typicode.github.io/husky/#/?id=yarn-2).
```
Hence I have incorporated the changes according to the instructions [here](https://typicode.github.io/husky/#/?id=yarn-2).

## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
-->
