### PR TITLE
(fix) Add type property to `patientResultUrl` config schema

### DIFF
--- a/packages/esm-home-app/src/openmrs-esm-home-schema.ts
+++ b/packages/esm-home-app/src/openmrs-esm-home-schema.ts
@@ -29,6 +29,7 @@ export const esmHomeSchema = {
   },
   search: {
     patientResultUrl: {
+      _type: Type.String,
       _default: '${openmrsSpaBase}/patient/${patientUuid}/chart',
       _description: 'Where clicking a patient result takes the user. Accepts template parameter ${patientUuid}',
       _validators: [validators.isUrlWithTemplateParameters(['patientUuid'])],


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

Adds a `Type` property to the `patientResultUrl` config schema property. Presently, the `patientResultUrl` property is not editable via the implementer tools, and though I don't think this fixes it, it's still a worthwhile fix nonetheless.