### PR TITLE
feat: Add ability to configure OpenMRS logo on home-dashboard

### DIFF
--- a/packages/esm-home-app/src/dashboard/home-dashboard.component.tsx
+++ b/packages/esm-home-app/src/dashboard/home-dashboard.component.tsx
@@ -25,11 +25,13 @@ export default function HomeDashboard() {
           </div>
         </section>
       </div>
-      <section className={styles.logoSection}>
-        <svg>
-          <use xlinkHref="#omrs-logo-full-mono" />
-        </svg>
-      </section>
+      {config.showOpenMRSLogo && (
+        <section className={styles.logoSection}>
+          <svg>
+            <use xlinkHref="#omrs-logo-full-mono" />
+          </svg>
+        </section>
+      )}
     </>
   );
 }

--- a/packages/esm-home-app/src/openmrs-esm-home-schema.ts
+++ b/packages/esm-home-app/src/openmrs-esm-home-schema.ts
@@ -34,4 +34,9 @@ export const esmHomeSchema = {
       _validators: [validators.isUrlWithTemplateParameters(['patientUuid'])],
     },
   },
+  showOpenMRSLogo: {
+    _type: Type.Boolean,
+    _description: 'Whether to display OpenMRS logo on home dashboard',
+    _default: true,
+  },
 };


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

- Add ability to configure `OpenMRS` logo on home-dashboard. By default the OpenMRS logo will display


## Screenshots

![Kapture 2022-11-17 at 15 15 01](https://user-images.githubusercontent.com/28008754/202443970-fcce8c60-4ccb-44ed-9ab9-cfb16aebaf9e.gif)

## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
-->
