### PR TITLE
(chore) Cache built artefacts from bundle size action runs

### DIFF
--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -10,9 +10,24 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Setup local cache server for Turborepo
+        uses: felixmosh/turborepo-gh-artifacts@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          server-token: ${{ secrets.TURBO_SERVER_TOKEN }}
+
       - uses: actions/checkout@v3
-      - uses: preactjs/compressed-size-action@v2
+      - name: Compute bundle size changes
+        uses: preactjs/compressed-size-action@v2
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           minimum-change-threshold: 10000 # 10 KB
-          build-script: "turbo run build --color --no-cache"
+          build-script: "turbo run build --color --api='http://127.0.0.1:9080' --token=${{ secrets.TURBO_SERVER_TOKEN }} --team='${{ github.repository_owner }}'" 
+
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: packages
+          path: |
+            packages/**/dist

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           minimum-change-threshold: 10000 # 10 KB
-          build-script: "turbo run build --color --api='http://127.0.0.1:9080' --token=${{ secrets.TURBO_SERVER_TOKEN }} --team='${{ github.repository_owner }}'" 
+          build-script: "turbo run build --color --api=\"http://127.0.0.1:9080\" --token=\"${{ secrets.TURBO_SERVER_TOKEN }}\" --team=\"${{ github.repository_owner }}\"" 
 
 
       - name: Upload build artifacts

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -26,7 +26,7 @@ jobs:
 
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: packages
           path: |


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

Presently, the bundle size workflow is taking a lot longer to run compared to our primary CI workflow. This is likely because the bundle size workflow doesn't leverage the caching benefits offered by Turborepo. This PR attempts to set up [remote caching](https://turbo.build/repo/docs/core-concepts/remote-caching) within the workflow. 