### PR TITLE
(feat) Set a `max-width` for tiles on the home page

### DIFF
--- a/packages/esm-home-app/src/dashboard/home-dashboard.css
+++ b/packages/esm-home-app/src/dashboard/home-dashboard.css
@@ -11,6 +11,7 @@
 
 :global(.omrs-breakpoint-gt-phone) .homeDashboard {
   height: calc(100vh - var(--omrs-topnav-height) - 10rem);
+  max-width: 60rem;
 }
 
 .mainSection {


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

Sets a `max-width` for tiles on the home page. Ensures consistency with tiles in the patient chart.

## Screenshots

<img width="1244" alt="Screenshot 2023-03-11 at 9 43 25 PM" src="https://user-images.githubusercontent.com/8509731/224506083-50c66e95-d66d-41b4-b2c7-ce9070b0ca66.png">
