### PR TITLE
(fix) make `home-page-widgets` the default view

### DIFF
--- a/packages/esm-home-app/src/dashboard.meta.ts
+++ b/packages/esm-home-app/src/dashboard.meta.ts
@@ -1,5 +1,5 @@
 export const homeWidgetDashboardMeta = {
   name: 'Home',
   slot: 'home-dashboard-slot',
-  title: '',
+  title: 'home',
 };

--- a/packages/esm-home-app/src/dashboard/home-dashboard.component.tsx
+++ b/packages/esm-home-app/src/dashboard/home-dashboard.component.tsx
@@ -6,7 +6,6 @@ import { DashboardConfig } from '../types/index';
 import DashboardView from './dashboard-view.component';
 
 export default function HomeDashboard() {
-  const config = useConfig();
   const params = useParams();
   const extensionStore = useExtensionStore();
   const layout = useLayoutType();

--- a/packages/esm-home-app/src/dashboard/home-dashboard.scss
+++ b/packages/esm-home-app/src/dashboard/home-dashboard.scss
@@ -8,6 +8,19 @@
   height: 100vh;
   margin-left: 16rem;
   background-color: colors.$white-0;
+
+  /*TO BE REMOVED ONCE WE IMPROVE LEFT SIDE NAVIGATION*/
+  & li {
+    display: flex;
+  }
+
+  & a {
+    width: 100%;
+  }
+}
+/*TO BE REMOVED ONCE WE IMPROVE LEFT SIDE NAVIGATION*/
+li::marker{
+  font-size: 0px;
 }
 
 .logoSection {

--- a/packages/esm-home-app/src/index.ts
+++ b/packages/esm-home-app/src/index.ts
@@ -109,6 +109,7 @@ function setupOpenMRS() {
         meta: homeWidgetDashboardMeta,
         online: true,
         offline: true,
+        order: 0,
       },
       {
         id: 'home-widget-dashboard',


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

This PR fixes the left-nav to appear in the correct order until we have an improvement on the UI in a follow up PR. Second it enforces order by always making sure the `home-page-widget` slot is the first dashboard to be always seen.


## Screenshots
##Error
![errorDev3](https://user-images.githubusercontent.com/28008754/227651894-c48a0a53-7079-4fb4-a2f0-b47be82e0219.gif)

##Fix
![fix](https://user-images.githubusercontent.com/28008754/227651999-b5ef4af9-bc41-4154-aad4-b65efebc1d2c.gif)

## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
-->
