### PR TITLE
(feat) Redesigned home page navigation

### DIFF
--- a/packages/esm-home-app/src/createDashboardLink.tsx
+++ b/packages/esm-home-app/src/createDashboardLink.tsx
@@ -1,30 +1,37 @@
-import React from 'react';
-import { navigate } from '@openmrs/esm-framework';
-import { SideNavLink } from '@carbon/react';
-
-export const spaBasePath = `${window.spaBase}/home`;
+import React, { useMemo } from 'react';
+import { BrowserRouter, useLocation } from 'react-router-dom';
+import { ConfigurableLink } from '@openmrs/esm-framework';
 
 export interface DashboardLinkConfig {
   name: string;
   title: string;
-  renderIcon?: React.ComponentType<any>;
 }
 
-export const createDashboardLink = (db: DashboardLinkConfig) => {
-  const DashboardLink: React.FC = () => {
-    return (
-      <SideNavLink
-        key={db.name}
-        renderIcon={db.renderIcon}
-        href={`${spaBasePath}/${db.name}`}
-        onClick={(e) => {
-          e.preventDefault();
-          navigate({ to: `${spaBasePath}/${db.title}` });
-        }}
-      >
-        {db.name}
-      </SideNavLink>
-    );
-  };
-  return DashboardLink;
+const DashboardLink = ({ dashboardLinkConfig }: { dashboardLinkConfig: DashboardLinkConfig }) => {
+  const { name } = dashboardLinkConfig;
+  const location = useLocation();
+  const spaBasePath = `${window.spaBase}/home`;
+
+  const navLink = useMemo(() => {
+    const pathArray = location.pathname.split('/');
+    const lastElement = pathArray[pathArray.length - 1];
+    return decodeURIComponent(lastElement);
+  }, [location.pathname]);
+
+  return (
+    <ConfigurableLink
+      to={spaBasePath}
+      className={`cds--side-nav__link ${navLink === 'home' && 'active-left-nav-link'}`}
+    >
+      {name}
+    </ConfigurableLink>
+  );
+};
+
+export const createDashboardLink = (dashboardLinkConfig: DashboardLinkConfig) => {
+  return () => (
+    <BrowserRouter>
+      <DashboardLink dashboardLinkConfig={dashboardLinkConfig} />
+    </BrowserRouter>
+  );
 };

--- a/packages/esm-home-app/src/dashboard.meta.ts
+++ b/packages/esm-home-app/src/dashboard.meta.ts
@@ -1,5 +1,5 @@
-export const homeWidgetDashboardMeta = {
+export const dashboardMeta = {
   name: 'Home',
   slot: 'home-dashboard-slot',
-  title: 'home',
+  title: '',
 };

--- a/packages/esm-home-app/src/dashboard/home-dashboard.component.tsx
+++ b/packages/esm-home-app/src/dashboard/home-dashboard.component.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { useLayoutType, isDesktop, useExtensionStore, ExtensionSlot } from '@openmrs/esm-framework';
 import { useParams } from 'react-router-dom';
+import { useLayoutType, isDesktop, useExtensionStore, ExtensionSlot } from '@openmrs/esm-framework';
 import DashboardView from './dashboard-view.component';
 import type { DashboardConfig } from '../types/index';
 import styles from './home-dashboard.scss';
@@ -14,12 +14,12 @@ export default function HomeDashboard() {
       .map((e) => e.meta)
       .filter((e) => Object.keys(e).length) || [];
   const dashboards = ungroupedDashboards as Array<DashboardConfig>;
-  const currentDashboard = dashboards.find((dashboard) => dashboard.name === params?.view) || dashboards[0];
+  const activeDashboard = dashboards.find((dashboard) => dashboard.name === params?.dashboard) || dashboards[0];
 
   return (
     <section className={isDesktop(layout) && styles.dashboardContainer}>
       {isDesktop(layout) && <ExtensionSlot name="home-sidebar-slot" key={layout} />}
-      <DashboardView title={currentDashboard?.name} dashboardSlot={currentDashboard?.slot} />
+      <DashboardView title={activeDashboard?.name} dashboardSlot={activeDashboard?.slot} />
     </section>
   );
 }

--- a/packages/esm-home-app/src/index.ts
+++ b/packages/esm-home-app/src/index.ts
@@ -1,6 +1,6 @@
 import { registerBreadcrumbs, defineConfigSchema, getAsyncLifecycle, getSyncLifecycle } from '@openmrs/esm-framework';
 import { createDashboardLink } from './createDashboardLink';
-import { homeWidgetDashboardMeta } from './dashboard.meta';
+import { dashboardMeta } from './dashboard.meta';
 import { esmHomeSchema } from './openmrs-esm-home-schema';
 
 declare var __VERSION__: string;
@@ -55,8 +55,8 @@ function setupOpenMRS() {
       {
         id: 'home-widget-db-link',
         slot: 'homepage-dashboard-slot',
-        load: getSyncLifecycle(createDashboardLink(homeWidgetDashboardMeta), options),
-        meta: homeWidgetDashboardMeta,
+        load: getSyncLifecycle(createDashboardLink(dashboardMeta), options),
+        meta: dashboardMeta,
         online: true,
         offline: true,
         order: 0,

--- a/packages/esm-home-app/src/root.component.tsx
+++ b/packages/esm-home-app/src/root.component.tsx
@@ -1,23 +1,37 @@
-import { setLeftNav, unsetLeftNav } from '@openmrs/esm-framework';
 import React, { useEffect } from 'react';
-import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import { BrowserRouter, Route, Routes, useNavigate, useParams } from 'react-router-dom';
+import { setLeftNav, unsetLeftNav } from '@openmrs/esm-framework';
 import HomeDashboard from './dashboard/home-dashboard.component';
 
-export const spaBasePath = `${window.spaBase}`;
+function FilteredDashboard() {
+  const { dashboard } = useParams();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const knownDashboards = ['appointments', 'service-queues', 'patient-lists'];
+
+    if (!knownDashboards.includes(dashboard)) {
+      navigate('/home');
+    }
+  }, [dashboard, navigate]);
+
+  return <HomeDashboard />;
+}
 
 const Root: React.FC = () => {
+  const spaBasePath = window.spaBase;
+
   useEffect(() => {
     setLeftNav({ name: 'homepage-dashboard-slot', basePath: spaBasePath });
     return () => unsetLeftNav('homepage-dashboard-slot');
-  }, []);
+  }, [spaBasePath]);
+
   return (
     <BrowserRouter basename={window.spaBase}>
       <main className="omrs-main-content">
         <Routes>
-          <Route path="home">
-            <Route index element={<HomeDashboard />} />
-            <Route path=":view" element={<HomeDashboard />} />
-          </Route>
+          <Route path="/home" element={<HomeDashboard />} />
+          <Route path="/home/:dashboard/*" element={<FilteredDashboard />} />
         </Routes>
       </main>
     </BrowserRouter>

--- a/packages/esm-home-app/src/side-menu/side-menu.component.tsx
+++ b/packages/esm-home-app/src/side-menu/side-menu.component.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { LeftNavMenu } from '@openmrs/esm-framework';
-import styles from './side-menu.scss';
 
-const SideMenu = () => <LeftNavMenu className={styles.sideMenu} isFixedNav expanded isChildOfHeader={true} />;
+const SideMenu = () => <LeftNavMenu />;
 
 export default SideMenu;

--- a/packages/esm-home-app/src/side-menu/side-menu.scss
+++ b/packages/esm-home-app/src/side-menu/side-menu.scss
@@ -1,8 +1,0 @@
-@use '@carbon/colors';
-@use '@carbon/styles/scss/spacing';
-@import '~@openmrs/esm-styleguide/src/vars';
-
-.sideMenu {
-  padding-top: spacing.$spacing-05;
-  border-right: 1px solid $ui-03;
-}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

This PR redesigns the navigation experience on the home page to match that of the patient chart. Specifically, it:

- Refactors `createDashboardLink` to wrap the dashboard URL using `ConfigurableLink` instead of `SideNavLink`. We can now leverage existing styling to give prominence to the active dashboard, which gets determined by checking the dashboard name that matches the current page URL.
- Sets up a redirect to the home page when the user navigates to a dashboard route other than the known dashboard routes for patient lists, service queues, and appointments.

## Video

https://user-images.githubusercontent.com/8509731/227769492-c0e16c04-eabb-42a3-862e-a10aa1eb5d09.mp4
