### PR TITLE
(feat) Remove home page redirect

### DIFF
--- a/packages/esm-home-app/src/root.component.tsx
+++ b/packages/esm-home-app/src/root.component.tsx
@@ -1,22 +1,7 @@
 import React, { useEffect } from 'react';
-import { BrowserRouter, Route, Routes, useNavigate, useParams } from 'react-router-dom';
+import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import { setLeftNav, unsetLeftNav } from '@openmrs/esm-framework';
 import HomeDashboard from './dashboard/home-dashboard.component';
-
-function FilteredDashboard() {
-  const { dashboard } = useParams();
-  const navigate = useNavigate();
-
-  useEffect(() => {
-    const knownDashboards = ['appointments', 'service-queues', 'patient-lists'];
-
-    if (!knownDashboards.includes(dashboard)) {
-      navigate('/home');
-    }
-  }, [dashboard, navigate]);
-
-  return <HomeDashboard />;
-}
 
 const Root: React.FC = () => {
   const spaBasePath = window.spaBase;
@@ -31,7 +16,7 @@ const Root: React.FC = () => {
       <main className="omrs-main-content">
         <Routes>
           <Route path="/home" element={<HomeDashboard />} />
-          <Route path="/home/:dashboard/*" element={<FilteredDashboard />} />
+          <Route path="/home/:dashboard/*" element={<HomeDashboard />} />
         </Routes>
       </main>
     </BrowserRouter>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

Removes some logic that redirects the user to the home page if the user navigates to an unknown route. There's a utility to doing this, but it requires a better approach. Currently, for example, navigating to an improperly authored nested route would kick the user back to the home page. 


## Video


https://user-images.githubusercontent.com/8509731/229520911-ff256f9f-54fa-459c-b725-f57230467417.mp4

