### PR TITLE
(fix) Remove deprecated `extensionSlotName` prop

### DIFF
--- a/packages/esm-home-app/src/dashboard/dashboard-view.component.tsx
+++ b/packages/esm-home-app/src/dashboard/dashboard-view.component.tsx
@@ -3,13 +3,7 @@ import { ExtensionSlot } from '@openmrs/esm-framework';
 import styles from './dashboard-view.scss';
 
 const DashboardView: React.FC<{ dashboardSlot: string; title: string }> = ({ dashboardSlot, title }) => {
-  return (
-    <ExtensionSlot
-      className={styles.dashboardView}
-      extensionSlotName={dashboardSlot}
-      state={{ dashboardTitle: title }}
-    />
-  );
+  return <ExtensionSlot className={styles.dashboardView} name={dashboardSlot} state={{ dashboardTitle: title }} />;
 };
 
 export default DashboardView;

--- a/packages/esm-home-app/src/home-page-widgets/home-page-widgets.component.tsx
+++ b/packages/esm-home-app/src/home-page-widgets/home-page-widgets.component.tsx
@@ -5,7 +5,7 @@ import styles from './home-page-widgets.scss';
 interface HomePageWidgetsProps {}
 
 const HomePageWidgets: React.FC<HomePageWidgetsProps> = () => {
-  return <ExtensionSlot className={styles.homePageWidget} extensionSlotName="homepage-widgets-slot" />;
+  return <ExtensionSlot className={styles.homePageWidget} name="homepage-widgets-slot" />;
 };
 
 export default HomePageWidgets;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

Removes the deprecated `extensionSlotName` prop and replaces it with `name`.