### PR TITLE
(chore) Release `v5.0.0`

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -4,7 +4,7 @@
   ],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "4.2.0",
+  "version": "5.0.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/packages/esm-home-app/package.json
+++ b/packages/esm-home-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-home-app",
-  "version": "4.2.0",
+  "version": "5.0.0",
   "description": "Homepage microfrontend for the OpenMRS SPA",
   "browser": "dist/openmrs-esm-home-app.js",
   "main": "src/index.ts",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

This PR cuts a new `major` release of Home, `v5.0.0`.

## `5.0.0`

Home `v5.0.0` is a `major` release containing a BREAKING change. Specifically, it migrates this frontend module to the new module loading mechanism introduced in Core v5. 

Informed by the [migration guide](https://o3-docs.vercel.app/docs/migration-guide), this release introduces a `routes.json` file for configuring pages and extensions for this frontend module. It also makes the necessary changes to the app entry point (`src/index.ts`), including defining named exports for each extension and page. This metadata makes this module compatible with the new module loading mechanism, enabling us to leverage improved performance benefits. This is a BREAKING change, and all distros that use these modules will need to update their configurations to use the latest versions of the core framework and openmrs tooling.
