### PR TITLE
(fix) Incorrect display mode for grouped items in side navigation

### DIFF
--- a/packages/esm-home-app/src/dashboard/home-dashboard.scss
+++ b/packages/esm-home-app/src/dashboard/home-dashboard.scss
@@ -10,11 +10,6 @@
   margin-left: 16rem;
   background-color: colors.$white-0;
 
-  /*TO BE REMOVED ONCE WE IMPROVE LEFT SIDE NAVIGATION*/
-  & li {
-    display: flex;
-  }
-
   & a {
     width: 100%;
   }


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
- Fixed incorrect display mode for grouped items in side navigation, flex mode hides items on the side
@vasharma05 @denniskigen please confirm that there is no use case for this

<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots
<img width="285" alt="Screenshot 2024-01-09 at 14 44 23" src="https://github.com/openmrs/openmrs-esm-home/assets/19533785/a478c29c-d70e-4897-b659-daaf2b50e1b6">

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
-->
