### PR TITLE
(chore) Add GitHub Actions flows to automate Transifex and upgrade config

### DIFF
--- a/.github/workflows/tx-pull.yml
+++ b/.github/workflows/tx-pull.yml
@@ -1,0 +1,31 @@
+on:
+  workflow_dispatch:
+  schedule:
+    # every day at 8:05 PM UTC
+    - cron: "0 20 5 * *"
+
+name: "Scheduled Transifex Update"
+
+jobs:
+  pull-translations-from-transifex:
+    name: pull-translations-from-transifex
+    
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Push source file using transifex client
+        uses: transifex/cli-action@v2
+        with:
+          token: ${{ secrets.TRANSIFEX_TOKEN }}
+          args: pull
+      - name: Create PR if necessary
+        uses: peter-evans/create-pull-request@v5
+        with:
+          commit-message: "(chore) Update translations from Transifex"
+          title: "(chore) Update translations from Transifex"
+          body: "Automated updates of translations pulled from Transifex"
+          branch: "chore/update-transifex"
+          author: "OpenMRS Bot <infrastructure@openmrs.org>"
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tx-push.yml
+++ b/.github/workflows/tx-push.yml
@@ -1,0 +1,21 @@
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+
+name: "Update Transifex on Push"
+
+jobs:
+  push-translations-to-transifex:
+    name: push-translations-to-transifex
+
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    
+    steps:
+      - uses: actions/checkout@v4
+      - name: Push source file using transifex client
+        uses: transifex/cli-action@v2
+        with:
+          token: ${{ secrets.TRANSIFEX_TOKEN }}

--- a/.tx/config
+++ b/.tx/config
@@ -1,9 +1,12 @@
 [main]
 host = https://www.transifex.com
 
-[openmrs-esm-home.esm-home-app]
-file_filter = packages/esm-home-app/translations/<lang>.json
-minimum_perc = 0
-source_file = packages/esm-home-app/translations/en.json
-source_lang = en
-type = KEYVALUEJSON
+[o:openmrs:p:openmrs-esm-home:r:esm-home-app]
+file_filter            = packages/esm-home-app/translations/<lang>.json
+source_file            = packages/esm-home-app/translations/en.json
+source_lang            = en
+type                   = KEYVALUEJSON
+minimum_perc           = 0
+replace_edited_strings = false
+keep_translations      = false
+


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

This PR adds two GitHub Actions workflows aimed at automating (to an extent) our use of Transifex. Specifically:

* `tx-push`: Run on every push to main, this pushes the translation files to Transifex to ensure the strings on Transifex are up-to-date.
 * `tx-pull`: This is a scheduled job run daily at 8:10 PM UTC, which is fairly arbitrary. It pulls changes from Transifex and, if any updates are made (🤞), it should create a PR to update those files. Subsequent updates before a PR is merged should update the PR in question.

Aside from the time difference on tx-pull, this is identical to https://github.com/openmrs/openmrs-esm-core/pull/887


## Screenshots



## Related Issue

## Other
