### PR TITLE
Editing a default value should update the translation files

### DIFF
--- a/packages/esm-home-app/translations/fr.json
+++ b/packages/esm-home-app/translations/fr.json
@@ -1,3 +1,3 @@
 {
-  "Home": "Home"
+  "Home": "Maison"
 }

--- a/tools/i18next-parser.config.js
+++ b/tools/i18next-parser.config.js
@@ -76,6 +76,12 @@ module.exports = {
   failOnWarnings: false,
   // Exit with an exit code of 1 on warnings
 
+  resetDefaultValueLocale: 'en',
+  // The locale to compare with default values to determine whether a default value has been changed.
+  // If this is set and a default value differs from a translation in the specified locale, all entries
+  // for that key across locales are reset to the default value, and existing translations are moved to
+  // the `_old` file.
+
   customValueTemplate: null,
   // If you wish to customize the value output the value as an object, you can set your own format.
   // ${defaultValue} is the default value you set in your translation function.


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
This PR updates the translation files if the default value of the translation key is changed.

Referenced issue: https://github.com/i18next/i18next-parser/issues/267
Referenced PR: https://github.com/i18next/i18next-parser/pull/451


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
-->


## Related Issue
[issues.openmrs.org/browse/O3-2538](https://issues.openmrs.org/browse/O3-2538)

## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
-->
