### PR TITLE
(chore) Release v5.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-home",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "workspaces": [
     "packages/*"
   ],
@@ -10,7 +10,7 @@
   "scripts": {
     "ci:publish": "yarn workspaces foreach --all --topological --exclude @openmrs/esm-home npm publish --access public --tag latest",
     "ci:prepublish": "yarn workspaces foreach --all --topological --exclude @openmrs/esm-home npm publish --access public --tag next",
-    "ci:release": "yarn workspaces foreach --all --topological version",
+    "release": "yarn workspaces foreach --all --topological version",
     "prettier": "prettier --config prettier.config.js --write \"packages/**/*.{ts,tsx}\"",
     "postinstall": "husky install",
     "start": "openmrs develop --sources 'packages/esm-*-app/'",

--- a/packages/esm-home-app/package.json
+++ b/packages/esm-home-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-home-app",
-  "version": "5.2.0",
+  "version": "5.2.2",
   "description": "Homepage microfrontend for the OpenMRS SPA",
   "browser": "dist/openmrs-esm-home-app.js",
   "main": "src/index.ts",


### PR DESCRIPTION

 
This resolves the issue discussed here: https://github.com/openmrs/openmrs-distro-referenceapplication/pull/782#issuecomment-1934555801. 

The reason the package didn't get pushed to the registry is that there was no overridden release command, which resulted in only the version number in the root package.json file being incremented.

I renamed `ci:release` to `release` as there was no usage of `ci:release` found.