### PR TITLE
(chore) O3-2981: Remove stray semi-colon from home page

### DIFF
--- a/packages/esm-home-app/src/dashboard/dashboard-view.component.tsx
+++ b/packages/esm-home-app/src/dashboard/dashboard-view.component.tsx
@@ -6,7 +6,7 @@ const DashboardView: React.FC<{ dashboardSlot: string; title: string }> = ({ das
   return (
     <>
       <ExtensionSlot name="home-metrics-widgets-slot" />
-      <ExtensionSlot className={styles.dashboardView} name={dashboardSlot} state={{ dashboardTitle: title }} />;
+      <ExtensionSlot className={styles.dashboardView} name={dashboardSlot} state={{ dashboardTitle: title }} />
     </>
   );
 };


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
This PR basically removes a stray semi-colon from the home page
<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
-->


## Related Issue
https://openmrs.atlassian.net/browse/O3-2981

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
-->


## Other
Before

![appointments_home](https://github.com/openmrs/openmrs-esm-home/assets/19818300/7090c8b4-3f38-4937-9d41-264484bfe24e)

After

![after](https://github.com/openmrs/openmrs-esm-home/assets/19818300/a5067838-5388-48a4-9547-f51c1935cdeb)


*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
-->
