### PR TITLE
(fix) O3-3004: Home Dashboard Background Color should be gray

### DIFF
--- a/packages/esm-home-app/src/dashboard/home-dashboard.scss
+++ b/packages/esm-home-app/src/dashboard/home-dashboard.scss
@@ -5,10 +5,10 @@
   display: flex;
   flex-direction: column;
   margin: 0;
-  // Full vertical height minus the primary navigation menu height 
+  // Full vertical height minus the primary navigation menu height
   height: calc(100vh - 3rem);
   margin-left: 16rem;
-  background-color: colors.$white-0;
+  background-color: colors.$gray-10;
 
   & a {
     width: 100%;


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
-->
