### PR TITLE
(fix) Remove styles from metrics extension slot

### DIFF
--- a/packages/esm-home-app/src/metrics/metrics.component.tsx
+++ b/packages/esm-home-app/src/metrics/metrics.component.tsx
@@ -1,9 +1,8 @@
 import { ExtensionSlot } from '@openmrs/esm-framework';
 import React from 'react';
-import styles from './metrics.scss';
 
 const Metrics: React.FC = () => {
-  return <ExtensionSlot className={styles.metrics} name="home-metrics-tiles-slot" />;
+  return <ExtensionSlot name="home-metrics-tiles-slot" />;
 };
 
 export default Metrics;

--- a/packages/esm-home-app/src/metrics/metrics.scss
+++ b/packages/esm-home-app/src/metrics/metrics.scss
@@ -1,3 +1,0 @@
-.metrics {
-  display: flex;
-}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
In a bid to make the metrics `extension-slot` more generic and accommodating to extensions loaded into it, this PR removes CSS styles applied to the newly introduced metrics `extension-slot`.
<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
-->
