### PR TITLE
(feat) O3-2724: Move overlays into the framework

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@babel/core": "^7.22.17",
     "@carbon/react": "^1.37.0",
-    "@openmrs/esm-framework": "^5.5.1-pre.1665",
+    "@openmrs/esm-framework": "next",
     "@swc/cli": "^0.1.62",
     "@swc/core": "^1.3.84",
     "@swc/jest": "^0.2.29",
@@ -42,7 +42,7 @@
     "jest-cli": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "lint-staged": "^14.0.1",
-    "openmrs": "^5.5.1-pre.1665",
+    "openmrs": "next",
     "prettier": "^3.0.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
@@ -54,8 +54,7 @@
     "turbo": "^1.10.13",
     "typescript": "^4.9.5",
     "webpack": "^5.88.2",
-    "webpack-cli": "^4.10.0",
-    "webpack-dev-server": "^4.15.1"
+    "webpack-cli": "^5.1.4"
   },
   "lint-staged": {
     "*.{ts,tsx}": "eslint --cache --fix --max-warnings 0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@babel/core": "^7.22.17",
     "@carbon/react": "^1.37.0",
-    "@openmrs/esm-framework": "next",
+    "@openmrs/esm-framework": "^5.5.1-pre.1665",
     "@swc/cli": "^0.1.62",
     "@swc/core": "^1.3.84",
     "@swc/jest": "^0.2.29",
@@ -42,7 +42,7 @@
     "jest-cli": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "lint-staged": "^14.0.1",
-    "openmrs": "next",
+    "openmrs": "^5.5.1-pre.1665",
     "prettier": "^3.0.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
@@ -54,7 +54,8 @@
     "turbo": "^1.10.13",
     "typescript": "^4.9.5",
     "webpack": "^5.88.2",
-    "webpack-cli": "^5.1.4"
+    "webpack-cli": "^4.10.0",
+    "webpack-dev-server": "^4.15.1"
   },
   "lint-staged": {
     "*.{ts,tsx}": "eslint --cache --fix --max-warnings 0",

--- a/packages/esm-home-app/src/root.component.tsx
+++ b/packages/esm-home-app/src/root.component.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
-import { setLeftNav, unsetLeftNav } from '@openmrs/esm-framework';
+import { WorkspaceOverlay, setLeftNav, unsetLeftNav } from '@openmrs/esm-framework';
 import HomeDashboard from './dashboard/home-dashboard.component';
 
 const Root: React.FC = () => {
@@ -12,14 +12,17 @@ const Root: React.FC = () => {
   }, [spaBasePath]);
 
   return (
-    <BrowserRouter basename={window.spaBase}>
-      <main className="omrs-main-content">
-        <Routes>
-          <Route path="/home" element={<HomeDashboard />} />
-          <Route path="/home/:dashboard/*" element={<HomeDashboard />} />
-        </Routes>
-      </main>
-    </BrowserRouter>
+    <>
+      <BrowserRouter basename={window.spaBase}>
+        <main className="omrs-main-content">
+          <Routes>
+            <Route path="/home" element={<HomeDashboard />} />
+            <Route path="/home/:dashboard/*" element={<HomeDashboard />} />
+          </Routes>
+        </main>
+      </BrowserRouter>
+      <WorkspaceOverlay contextKey="home" />
+    </>
   );
 };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,11 +14,17 @@
       "es2015.promise",
       "es2016.array.include",
       "es2018",
-      "es2020"
+      "es2020",
+      "es2021"
     ],
     "resolveJsonModule": true,
     "strictNullChecks": true,
     "noEmit": true,
-    "target": "esnext"
+    "target": "esnext",
+    "paths": {
+      "@openmrs/*": ["./node_modules/@openmrs/*"],
+      "__mocks__": ["./__mocks__"],
+      "tools": ["./tools"],
+    }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1701,7 +1701,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/icons-react@npm:^11.26.0":
+"@carbon/icons-react@npm:11.26.0, @carbon/icons-react@npm:^11.26.0":
   version: 11.26.0
   resolution: "@carbon/icons-react@npm:11.26.0"
   dependencies:
@@ -1728,7 +1728,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/react@npm:^1.37.0":
+"@carbon/react@npm:^1.37.0, @carbon/react@npm:~1.37.0":
   version: 1.37.0
   resolution: "@carbon/react@npm:1.37.0"
   dependencies:
@@ -3132,27 +3132,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openmrs/esm-api@npm:5.2.1-pre.1156":
-  version: 5.2.1-pre.1156
-  resolution: "@openmrs/esm-api@npm:5.2.1-pre.1156"
+"@openmrs/esm-api@npm:5.5.1-pre.1720":
+  version: 5.5.1-pre.1720
+  resolution: "@openmrs/esm-api@npm:5.5.1-pre.1720"
   dependencies:
     "@types/fhir": "npm:0.0.31"
     lodash-es: "npm:^4.17.21"
   peerDependencies:
     "@openmrs/esm-config": 5.x
     "@openmrs/esm-error-handling": 5.x
+    "@openmrs/esm-navigation": 5.x
     "@openmrs/esm-offline": 5.x
-  checksum: 10/c59e1e7cdddf600d242f0cc44b6e84ddbd343ec84b6aa69d03259f5cce71efe3219fbb378c94a1410ebbf0b441b287739b1743ce735c2394bec2fdcf0be3c6d5
+  checksum: 10/d804702af09dad452456b6a5886cac0f39fc49d531e4df077e3ede82ecd46c8b4861dd95850a51e987b4066fd9b7b36b9b9c2044e58767e36dbe549dbb029887
   languageName: node
   linkType: hard
 
-"@openmrs/esm-app-shell@npm:5.2.1-pre.1156":
-  version: 5.2.1-pre.1156
-  resolution: "@openmrs/esm-app-shell@npm:5.2.1-pre.1156"
+"@openmrs/esm-app-shell@npm:5.5.1-pre.1720":
+  version: 5.5.1-pre.1720
+  resolution: "@openmrs/esm-app-shell@npm:5.5.1-pre.1720"
   dependencies:
-    "@carbon/react": "npm:^1.37.0"
-    "@openmrs/esm-framework": "npm:5.2.1-pre.1156"
-    "@openmrs/esm-styleguide": "npm:5.2.1-pre.1156"
+    "@carbon/react": "npm:~1.37.0"
+    "@openmrs/esm-framework": "npm:5.5.1-pre.1720"
+    "@openmrs/esm-styleguide": "npm:5.5.1-pre.1720"
     dayjs: "npm:^1.10.4"
     dexie: "npm:^3.0.3"
     html-webpack-plugin: "npm:^5.5.0"
@@ -3166,7 +3167,7 @@ __metadata:
     react-router-dom: "npm:^6.3.0"
     rxjs: "npm:^6.5.3"
     semver: "npm:^7.3.4"
-    single-spa: "npm:^5.9.2"
+    single-spa: "npm:^6.0.1"
     swc-loader: "npm:^0.2.3"
     swr: "npm:^2.2.2"
     systemjs: "npm:^6.8.3"
@@ -3177,55 +3178,44 @@ __metadata:
     workbox-strategies: "npm:^6.1.5"
     workbox-webpack-plugin: "npm:^6.1.5"
     workbox-window: "npm:^6.1.5"
-  checksum: 10/5e10e1ddefcfd874c57cce106c36db7690bc52d02ef496095eba44b4b413578a2886832f4be9a008177415d2470fe457ab071f72c941f7cd0db7dc30b9dd78f9
+  checksum: 10/c48b7fb5197fb97d16d981e3203bc80c477feb8950f4a90658487d56d65532ccfcf0a04846d0ba5a4bfb1dc1472ee5264c68908388e9f0757d199efc0ef937b8
   languageName: node
   linkType: hard
 
-"@openmrs/esm-breadcrumbs@npm:5.2.1-pre.1156":
-  version: 5.2.1-pre.1156
-  resolution: "@openmrs/esm-breadcrumbs@npm:5.2.1-pre.1156"
-  dependencies:
-    path-to-regexp: "npm:6.1.0"
-  peerDependencies:
-    "@openmrs/esm-state": 5.x
-  checksum: 10/26a9ed07ff73be542a20dd31a8cb198bdac1908bbf997f63df5d81dacbb761f279ac29e52b8f20f56de5af60d96d8f79da576c39b2eeab990519c7650d231ca0
-  languageName: node
-  linkType: hard
-
-"@openmrs/esm-config@npm:5.2.1-pre.1156":
-  version: 5.2.1-pre.1156
-  resolution: "@openmrs/esm-config@npm:5.2.1-pre.1156"
+"@openmrs/esm-config@npm:5.5.1-pre.1720":
+  version: 5.5.1-pre.1720
+  resolution: "@openmrs/esm-config@npm:5.5.1-pre.1720"
   dependencies:
     ramda: "npm:^0.26.1"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
     "@openmrs/esm-state": 5.x
     single-spa: 5.x
-  checksum: 10/1578df5d53146d66b7e78981efc8fe4e75d62d39935eebd91db4fad3f00a61f28839b50ca44f6c937698ed1887d4b2f94831ec0f36c49b97ad6ae5dbf04cff52
+  checksum: 10/3f633a4c58a2b31f6614dc5063df61e6643578efdb2a138d0c2a1d64bdfeb8c377bec6900fcc149ed0e57a7f53be11912d14dced0794799e52672168b2f3e132
   languageName: node
   linkType: hard
 
-"@openmrs/esm-dynamic-loading@npm:5.2.1-pre.1156":
-  version: 5.2.1-pre.1156
-  resolution: "@openmrs/esm-dynamic-loading@npm:5.2.1-pre.1156"
+"@openmrs/esm-dynamic-loading@npm:5.5.1-pre.1720":
+  version: 5.5.1-pre.1720
+  resolution: "@openmrs/esm-dynamic-loading@npm:5.5.1-pre.1720"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
-  checksum: 10/9778f56531ed07bfdd501bf4bd83a06229811b4cd23f9fc956eac96c75c129f61fac0edb346fb5eff5c636ec45169ed525f9d90949a6f518272f4b4da68f0939
+  checksum: 10/7a8af3c0f31c80201374952d4febfdaa45f954fbecde6c772a2b690e438cbfc99d77cff0e60780b8a9c334afb4ff91d570ec52f666c284f56f565d54787dc350
   languageName: node
   linkType: hard
 
-"@openmrs/esm-error-handling@npm:5.2.1-pre.1156":
-  version: 5.2.1-pre.1156
-  resolution: "@openmrs/esm-error-handling@npm:5.2.1-pre.1156"
+"@openmrs/esm-error-handling@npm:5.5.1-pre.1720":
+  version: 5.5.1-pre.1720
+  resolution: "@openmrs/esm-error-handling@npm:5.5.1-pre.1720"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
-  checksum: 10/afebbc441bacba68d9715d127e13b18300f2006c2f7d2e044b2e13bf431c5449da2b44ae17f1a3924d7dbdf2f248ae31d5e16c8800f296d060a276737df34f6c
+  checksum: 10/452c3b5dd6328b40e037d99453241451c6828ab732727bd39b98d02004aa08422573b282a2cd6086f16cde79df3969dc3a80faee5011b314b8e39db0edab554f
   languageName: node
   linkType: hard
 
-"@openmrs/esm-extensions@npm:5.2.1-pre.1156":
-  version: 5.2.1-pre.1156
-  resolution: "@openmrs/esm-extensions@npm:5.2.1-pre.1156"
+"@openmrs/esm-extensions@npm:5.5.1-pre.1720":
+  version: 5.5.1-pre.1720
+  resolution: "@openmrs/esm-extensions@npm:5.5.1-pre.1720"
   dependencies:
     lodash-es: "npm:^4.17.21"
   peerDependencies:
@@ -3234,60 +3224,62 @@ __metadata:
     "@openmrs/esm-feature-flags": 5.x
     "@openmrs/esm-state": 5.x
     single-spa: 5.x
-  checksum: 10/f623672b92918a69a8d47c1d287167d81d1b36ce0456c60f33a670d281dc67d20bd47187283a89581201f2743e11975ae9b0003569763a20715ba70baf9d9ec8
+  checksum: 10/39f62c286a37dbf18f81630155e801547a5e184cf9ea87bceeda9ce6cfe2c886a4e974d8de193b59cf976f3c4e51f314e676b6bb1877f9f39384f594e59dd973
   languageName: node
   linkType: hard
 
-"@openmrs/esm-feature-flags@npm:5.2.1-pre.1156":
-  version: 5.2.1-pre.1156
-  resolution: "@openmrs/esm-feature-flags@npm:5.2.1-pre.1156"
+"@openmrs/esm-feature-flags@npm:5.5.1-pre.1720":
+  version: 5.5.1-pre.1720
+  resolution: "@openmrs/esm-feature-flags@npm:5.5.1-pre.1720"
   dependencies:
     ramda: "npm:^0.26.1"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
     "@openmrs/esm-state": 5.x
     single-spa: 5.x
-  checksum: 10/ee3ab530cb86c7b754b3e74d30c3b52a60a7a684bf31a76c167a4b9bb9c7147a93e345ecc0956a285c49d368523fcbd125a287d5c75a995065fb665d065947f3
+  checksum: 10/bfbec73332f7ac4d46a656422594f8a9d8093e1b4390bfaa8d8db95bbfdadb9868a714078f291b66519b6f5b7d68ed23b8e9f1a83179f6ca3845553e215fb0c9
   languageName: node
   linkType: hard
 
-"@openmrs/esm-framework@npm:5.2.1-pre.1156, @openmrs/esm-framework@npm:next":
-  version: 5.2.1-pre.1156
-  resolution: "@openmrs/esm-framework@npm:5.2.1-pre.1156"
+"@openmrs/esm-framework@npm:5.5.1-pre.1720, @openmrs/esm-framework@npm:next":
+  version: 5.5.1-pre.1720
+  resolution: "@openmrs/esm-framework@npm:5.5.1-pre.1720"
   dependencies:
-    "@openmrs/esm-api": "npm:5.2.1-pre.1156"
-    "@openmrs/esm-breadcrumbs": "npm:5.2.1-pre.1156"
-    "@openmrs/esm-config": "npm:5.2.1-pre.1156"
-    "@openmrs/esm-dynamic-loading": "npm:5.2.1-pre.1156"
-    "@openmrs/esm-error-handling": "npm:5.2.1-pre.1156"
-    "@openmrs/esm-extensions": "npm:5.2.1-pre.1156"
-    "@openmrs/esm-feature-flags": "npm:5.2.1-pre.1156"
-    "@openmrs/esm-globals": "npm:5.2.1-pre.1156"
-    "@openmrs/esm-offline": "npm:5.2.1-pre.1156"
-    "@openmrs/esm-react-utils": "npm:5.2.1-pre.1156"
-    "@openmrs/esm-state": "npm:5.2.1-pre.1156"
-    "@openmrs/esm-styleguide": "npm:5.2.1-pre.1156"
-    "@openmrs/esm-utils": "npm:5.2.1-pre.1156"
+    "@openmrs/esm-api": "npm:5.5.1-pre.1720"
+    "@openmrs/esm-config": "npm:5.5.1-pre.1720"
+    "@openmrs/esm-dynamic-loading": "npm:5.5.1-pre.1720"
+    "@openmrs/esm-error-handling": "npm:5.5.1-pre.1720"
+    "@openmrs/esm-extensions": "npm:5.5.1-pre.1720"
+    "@openmrs/esm-feature-flags": "npm:5.5.1-pre.1720"
+    "@openmrs/esm-globals": "npm:5.5.1-pre.1720"
+    "@openmrs/esm-navigation": "npm:5.5.1-pre.1720"
+    "@openmrs/esm-offline": "npm:5.5.1-pre.1720"
+    "@openmrs/esm-react-utils": "npm:5.5.1-pre.1720"
+    "@openmrs/esm-routes": "npm:5.5.1-pre.1720"
+    "@openmrs/esm-state": "npm:5.5.1-pre.1720"
+    "@openmrs/esm-styleguide": "npm:5.5.1-pre.1720"
+    "@openmrs/esm-translations": "npm:5.5.1-pre.1720"
+    "@openmrs/esm-utils": "npm:5.5.1-pre.1720"
     dayjs: "npm:^1.10.7"
   peerDependencies:
     dayjs: 1.x
-    i18next: 19.x
+    i18next: 21.x
     react: 18.x
     react-dom: 18.x
     react-i18next: 11.x
     rxjs: 6.x
     single-spa: 5.x
     swr: 2.x
-  checksum: 10/33541cdee2bcfd016cf74f25e745463fbc25e6a6c5aa3af58018e4f108320c64d26eab4c3823adb21ab3acc032c43c9ad85b7a2adfa726f21675f0de36402b42
+  checksum: 10/7f3a689992f2aeb3d8fa37b2f4886db3b07b2d63099f8d90bc5ecaae79a09ef42703af895c7e7b8578d9e69c809df1fc36a1516eaa542f8455423e1ea797b1cb
   languageName: node
   linkType: hard
 
-"@openmrs/esm-globals@npm:5.2.1-pre.1156":
-  version: 5.2.1-pre.1156
-  resolution: "@openmrs/esm-globals@npm:5.2.1-pre.1156"
+"@openmrs/esm-globals@npm:5.5.1-pre.1720":
+  version: 5.5.1-pre.1720
+  resolution: "@openmrs/esm-globals@npm:5.5.1-pre.1720"
   peerDependencies:
     single-spa: 5.x
-  checksum: 10/9a5347f1e5a00e3e50a76c1154caf1f8ccb510cc51b940f492482d86558eb8499f9a93ea76211d2b19c9c1b17071e808d60338684bdbc0845e43d95a436cf172
+  checksum: 10/91d7280addee4d60918543696d8a80ccf4ea5e259c169ddfd4d76d0aad2c013299f354537e987dadd6f3bd6699624b427cb18954161c2ce238e0942a47471372
   languageName: node
   linkType: hard
 
@@ -3352,9 +3344,20 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-offline@npm:5.2.1-pre.1156":
-  version: 5.2.1-pre.1156
-  resolution: "@openmrs/esm-offline@npm:5.2.1-pre.1156"
+"@openmrs/esm-navigation@npm:5.5.1-pre.1720":
+  version: 5.5.1-pre.1720
+  resolution: "@openmrs/esm-navigation@npm:5.5.1-pre.1720"
+  dependencies:
+    path-to-regexp: "npm:6.1.0"
+  peerDependencies:
+    "@openmrs/esm-state": 5.x
+  checksum: 10/9269fc4abd6da77de1b12c016e7d9c611713c1f8af40eff411540c39214044433b2a688c86162264a65a5064d85904b619437c2979dc60e2c012cfa227729272
+  languageName: node
+  linkType: hard
+
+"@openmrs/esm-offline@npm:5.5.1-pre.1720":
+  version: 5.5.1-pre.1720
+  resolution: "@openmrs/esm-offline@npm:5.5.1-pre.1720"
   dependencies:
     dexie: "npm:^3.0.3"
     lodash-es: "npm:^4.17.21"
@@ -3366,83 +3369,112 @@ __metadata:
     "@openmrs/esm-state": 5.x
     "@openmrs/esm-styleguide": 5.x
     rxjs: 6.x
-  checksum: 10/773d1727e0d5ea3c5c4d278ca5e11569224f1b4da9d9818343fb037001ccea0d8a62d12947d9079774256bf3dc58abeb0b225ba858921bce71224d2d6a5e241c
+  checksum: 10/23deaab3475d1cc40e18461f61b311068caa234c5ec39be9019cdaf44fdd1e04c2269adf5393728e284d41388649c7f99a6b73744d5a99849607ac9931fbf73f
   languageName: node
   linkType: hard
 
-"@openmrs/esm-react-utils@npm:5.2.1-pre.1156":
-  version: 5.2.1-pre.1156
-  resolution: "@openmrs/esm-react-utils@npm:5.2.1-pre.1156"
+"@openmrs/esm-react-utils@npm:5.5.1-pre.1720":
+  version: 5.5.1-pre.1720
+  resolution: "@openmrs/esm-react-utils@npm:5.5.1-pre.1720"
   dependencies:
     lodash-es: "npm:^4.17.21"
-    single-spa-react: "npm:~5.0.0"
+    single-spa-react: "npm:^6.0.0"
   peerDependencies:
     "@openmrs/esm-api": 5.x
     "@openmrs/esm-config": 5.x
     "@openmrs/esm-error-handling": 5.x
     "@openmrs/esm-extensions": 5.x
+    "@openmrs/esm-feature-flags": 5.x
     "@openmrs/esm-globals": 5.x
+    "@openmrs/esm-navigation": 5.x
     dayjs: 1.x
-    i18next: 19.x
+    i18next: 21.x
     react: 18.x
     react-dom: 18.x
     react-i18next: 11.x
     rxjs: 6.x
     swr: 2.x
-  checksum: 10/33f5d950e9236ab0ecde6fd74ec918db03c20db84160925ac4407c5d68251c00af80fbe88045a7e30315fb8fec8aad8756e19a8576b933bd820bccbb73ce5d0a
+  checksum: 10/49dde90f9be5fcb6f69a1449e3bbb2c2419752d083fc4954e284f3cf61a8eab03c6b17ee7882d230c01185f681d91b7353f04e8e5486f37718a5dd239372a3b3
   languageName: node
   linkType: hard
 
-"@openmrs/esm-state@npm:5.2.1-pre.1156":
-  version: 5.2.1-pre.1156
-  resolution: "@openmrs/esm-state@npm:5.2.1-pre.1156"
+"@openmrs/esm-routes@npm:5.5.1-pre.1720":
+  version: 5.5.1-pre.1720
+  resolution: "@openmrs/esm-routes@npm:5.5.1-pre.1720"
+  peerDependencies:
+    "@openmrs/esm-globals": 5.x
+    "@openmrs/esm-utils": 5.x
+  checksum: 10/e56f7808df4196d4578853403b242de830ec5817d582c68a372b4ae4f05a52e91e36503f8445a008b070219a289a33b1fdf5ec5c43e22d416376804869d3fc2a
+  languageName: node
+  linkType: hard
+
+"@openmrs/esm-state@npm:5.5.1-pre.1720":
+  version: 5.5.1-pre.1720
+  resolution: "@openmrs/esm-state@npm:5.5.1-pre.1720"
   dependencies:
     zustand: "npm:^4.3.6"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
-  checksum: 10/5098e60c78f8d11c981733076d04e0182c0aa90007e63cc885e253da0908cdbb78620e7472b1200b6810f0748b80085e951cc9214ffaaed32d6733f344e1de6e
+  checksum: 10/c279aecbed8b57391b4ef28d4d84ad33b4e28930fa6d75d6236c2cf460a08e80d1e734bd00347071586e239dfb84438c99745610bd675d090fd2c5a826ba47f1
   languageName: node
   linkType: hard
 
-"@openmrs/esm-styleguide@npm:5.2.1-pre.1156":
-  version: 5.2.1-pre.1156
-  resolution: "@openmrs/esm-styleguide@npm:5.2.1-pre.1156"
+"@openmrs/esm-styleguide@npm:5.5.1-pre.1720":
+  version: 5.5.1-pre.1720
+  resolution: "@openmrs/esm-styleguide@npm:5.5.1-pre.1720"
   dependencies:
     "@carbon/charts": "npm:^1.12.0"
-    "@carbon/react": "npm:^1.37.0"
+    "@carbon/react": "npm:~1.37.0"
     "@internationalized/date": "npm:^3.5.0"
     "@react-spectrum/datepicker": "npm:^3.8.0"
     "@react-spectrum/provider": "npm:^3.9.0"
     "@react-spectrum/theme-default": "npm:^3.5.6"
+    core-js-pure: "npm:^3.36.0"
     d3: "npm:^7.8.0"
+    geopattern: "npm:^1.2.3"
     lodash-es: "npm:^4.17.21"
+    react-avatar: "npm:^5.0.3"
   peerDependencies:
     "@openmrs/esm-extensions": 5.x
     "@openmrs/esm-react-utils": 5.x
     "@openmrs/esm-state": 5.x
+    "@openmrs/esm-translations": 5.x
+    dayjs: 1.x
+    i18next: 21.x
     react: 18.x
     react-dom: 18.x
     rxjs: 6.x
-  checksum: 10/67f55f0789455562f34d70f3732a354ee1a60596193f8428c799aced29e751d6939e3475260d61d2924a4aa6a537031ff7914227b10a1fcd1b068a03764b7434
+  checksum: 10/289427f373cd976a221556369b7b96036d75fb88c6744bd3d1b06d68635e7be1d78e2d2fdd1e64a294cf30ba1480ac5ee070eb32262b2186d96441fed5998979
   languageName: node
   linkType: hard
 
-"@openmrs/esm-utils@npm:5.2.1-pre.1156":
-  version: 5.2.1-pre.1156
-  resolution: "@openmrs/esm-utils@npm:5.2.1-pre.1156"
+"@openmrs/esm-translations@npm:5.5.1-pre.1720":
+  version: 5.5.1-pre.1720
+  resolution: "@openmrs/esm-translations@npm:5.5.1-pre.1720"
+  dependencies:
+    i18next: "npm:21.10.0"
+  peerDependencies:
+    i18next: 21.x
+  checksum: 10/a1e79d84679b94e3b64df42b5edd24ca650ea8ef6974e6246b71e66afa14b63ddff1c5ee5baa21478c32feb4ff02c7e964b2f3806ab3a4f2b68f6f731a58f6b6
+  languageName: node
+  linkType: hard
+
+"@openmrs/esm-utils@npm:5.5.1-pre.1720":
+  version: 5.5.1-pre.1720
+  resolution: "@openmrs/esm-utils@npm:5.5.1-pre.1720"
   dependencies:
     semver: "npm:7.3.2"
   peerDependencies:
     dayjs: 1.x
-    i18next: 19.x
+    i18next: 21.x
     rxjs: 6.x
-  checksum: 10/419efd53200c5ab904b06bf47fc64cb591eed7e4309a97431d63a29fac10bb769e18f966902d833bb08c5f703ddb6fe1e919b5c6c6d1f89d1276d1a7f160cbc4
+  checksum: 10/f97e5d78053ac350072b8e6b9e653fc336628e4dd7758d585318182cba53ccc24cded38890987fbfd3a885b2e5bb2207701772641b2252e89009b82504a60ed7
   languageName: node
   linkType: hard
 
-"@openmrs/webpack-config@npm:5.2.1-pre.1156":
-  version: 5.2.1-pre.1156
-  resolution: "@openmrs/webpack-config@npm:5.2.1-pre.1156"
+"@openmrs/webpack-config@npm:5.5.1-pre.1720":
+  version: 5.5.1-pre.1720
+  resolution: "@openmrs/webpack-config@npm:5.5.1-pre.1720"
   dependencies:
     "@swc/core": "npm:^1.3.58"
     clean-webpack-plugin: "npm:^4.0.0"
@@ -3459,7 +3491,7 @@ __metadata:
     webpack-stats-plugin: "npm:^1.0.3"
   peerDependencies:
     webpack: 5.x
-  checksum: 10/2e9ae0ebc57635dc95a80ad37a7612bd8eed03335d41c1f408833560a965854bc21c1246578fb0c20a8309259b6ba958637436ff6e90a5404b2919cf7cdc89cd
+  checksum: 10/66c53cb9e5e776c31ea19eaf5f61bf11812d958806afdd61cd226bda1742e8defd3b5adb379e215677459c121ba54321acc434bad2c9faeac05c4ba7e978f129
   languageName: node
   linkType: hard
 
@@ -6821,6 +6853,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"charenc@npm:0.0.2":
+  version: 0.0.2
+  resolution: "charenc@npm:0.0.2"
+  checksum: 10/81dcadbe57e861d527faf6dd3855dc857395a1c4d6781f4847288ab23cffb7b3ee80d57c15bba7252ffe3e5e8019db767757ee7975663ad2ca0939bb8fcaf2e5
+  languageName: node
+  linkType: hard
+
 "cheerio-select@npm:^2.1.0":
   version: 2.1.0
   resolution: "cheerio-select@npm:2.1.0"
@@ -7385,6 +7424,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"core-js-pure@npm:^3.36.0":
+  version: 3.37.0
+  resolution: "core-js-pure@npm:3.37.0"
+  checksum: 10/196116e73370d075be9a95fe3605c210f8e53c7c18aeefe491fd9bc6442f2c1887d4b43128777bf4a5824d207e258578b507fc3d711a6ceb6144de500f2ffa23
+  languageName: node
+  linkType: hard
+
 "core-util-is@npm:~1.0.0":
   version: 1.0.3
   resolution: "core-util-is@npm:1.0.3"
@@ -7466,6 +7512,13 @@ __metadata:
     shebang-command: "npm:^2.0.0"
     which: "npm:^2.0.1"
   checksum: 10/e1a13869d2f57d974de0d9ef7acbf69dc6937db20b918525a01dacb5032129bd552d290d886d981e99f1b624cb03657084cc87bd40f115c07ecf376821c729ce
+  languageName: node
+  linkType: hard
+
+"crypt@npm:0.0.2":
+  version: 0.0.2
+  resolution: "crypt@npm:0.0.2"
+  checksum: 10/2c72768de3d28278c7c9ffd81a298b26f87ecdfe94415084f339e6632f089b43fe039f2c93f612bcb5ffe447238373d93b2e8c90894cba6cfb0ac7a74616f8b9
   languageName: node
   linkType: hard
 
@@ -9235,6 +9288,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"extend@npm:~1.2.1":
+  version: 1.2.1
+  resolution: "extend@npm:1.2.1"
+  checksum: 10/bfebc6fd4d924f9a8872cfebbda8fc543bae58ca3ec7fe7a5189a706402bd465559b82a106db589088d60e8348e04d8597a1d3760cb5e3d8cf184bcd924ac569
+  languageName: node
+  linkType: hard
+
 "external-editor@npm:^3.0.3":
   version: 3.1.0
   resolution: "external-editor@npm:3.1.0"
@@ -9750,6 +9810,15 @@ __metadata:
   version: 1.0.0-beta.2
   resolution: "gensync@npm:1.0.0-beta.2"
   checksum: 10/17d8333460204fbf1f9160d067e1e77f908a5447febb49424b8ab043026049835c9ef3974445c57dbd39161f4d2b04356d7de12b2eecaa27a7a7ea7d871cbedd
+  languageName: node
+  linkType: hard
+
+"geopattern@npm:^1.2.3":
+  version: 1.2.3
+  resolution: "geopattern@npm:1.2.3"
+  dependencies:
+    extend: "npm:~1.2.1"
+  checksum: 10/75a2a7149b4615ec59ed89613155c8252d758de49a52aa3ac45398c83d821b6fe0db3252e573b9117f4e56530745a17f1ac666c484709a467da08c6a59aa7cda
   languageName: node
   linkType: hard
 
@@ -10478,7 +10547,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"i18next@npm:^21.10.0":
+"i18next@npm:21.10.0, i18next@npm:^21.10.0":
   version: 21.10.0
   resolution: "i18next@npm:21.10.0"
   dependencies:
@@ -10863,7 +10932,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-buffer@npm:^1.1.5":
+"is-buffer@npm:^1.1.5, is-buffer@npm:~1.1.6":
   version: 1.1.6
   resolution: "is-buffer@npm:1.1.6"
   checksum: 10/f63da109e74bbe8947036ed529d43e4ae0c5fcd0909921dce4917ad3ea212c6a87c29f525ba1d17c0858c18331cf1046d4fc69ef59ed26896b25c8288a627133
@@ -11114,6 +11183,13 @@ __metadata:
   dependencies:
     is-unc-path: "npm:^1.0.0"
   checksum: 10/3271a0df109302ef5e14a29dcd5d23d9788e15ade91a40b942b035827ffbb59f7ce9ff82d036ea798541a52913cbf9d2d0b66456340887b51f3542d57b5a4c05
+  languageName: node
+  linkType: hard
+
+"is-retina@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "is-retina@npm:1.0.3"
+  checksum: 10/7f8306095851aaa55d7dd4a2edffb53942f45388d4d19299a788ca7d30f9f2b7ae0884237b2262a5f8a6d9d5f57e934da3fdbec60b174469054ef080ac29012f
   languageName: node
   linkType: hard
 
@@ -12569,6 +12645,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"md5@npm:^2.0.0":
+  version: 2.3.0
+  resolution: "md5@npm:2.3.0"
+  dependencies:
+    charenc: "npm:0.0.2"
+    crypt: "npm:0.0.2"
+    is-buffer: "npm:~1.1.6"
+  checksum: 10/88dce9fb8df1a084c2385726dcc18c7f54e0b64c261b5def7cdfe4928c4ee1cd68695c34108b4fab7ecceb05838c938aa411c6143df9fdc0026c4ddb4e4e72fa
+  languageName: node
+  linkType: hard
+
 "mdn-data@npm:2.0.14":
   version: 2.0.14
   resolution: "mdn-data@npm:2.0.14"
@@ -13031,6 +13118,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-watch@npm:^0.7.4":
+  version: 0.7.4
+  resolution: "node-watch@npm:0.7.4"
+  checksum: 10/ea752dd5cd0aa1344ced1002409c8a81829cc5406fd949f34e8886786f2015651d2da9c3d3d4f164d23b9e84c7062ff97051746fe77db18955ffb23dc3dc0b76
+  languageName: node
+  linkType: hard
+
 "nopt@npm:^5.0.0":
   version: 5.0.0
   resolution: "nopt@npm:5.0.0"
@@ -13354,16 +13448,18 @@ __metadata:
   linkType: hard
 
 "openmrs@npm:next":
-  version: 5.2.1-pre.1156
-  resolution: "openmrs@npm:5.2.1-pre.1156"
+  version: 5.5.1-pre.1720
+  resolution: "openmrs@npm:5.5.1-pre.1720"
   dependencies:
-    "@openmrs/esm-app-shell": "npm:5.2.1-pre.1156"
-    "@openmrs/webpack-config": "npm:5.2.1-pre.1156"
+    "@carbon/icons-react": "npm:11.26.0"
+    "@openmrs/esm-app-shell": "npm:5.5.1-pre.1720"
+    "@openmrs/webpack-config": "npm:5.5.1-pre.1720"
     "@pnpm/npm-conf": "npm:^2.1.0"
     "@swc/core": "npm:^1.3.58"
     autoprefixer: "npm:^10.4.2"
     axios: "npm:^0.21.1"
     browserslist-config-openmrs: "npm:^1.0.1"
+    chalk: "npm:^4.1.2"
     copy-webpack-plugin: "npm:^11.0.0"
     cssnano: "npm:^5.0.16"
     ejs: "npm:^3.1.8"
@@ -13371,6 +13467,7 @@ __metadata:
     html-webpack-plugin: "npm:^5.5.0"
     inquirer: "npm:^7.3.3"
     mini-css-extract-plugin: "npm:^2.4.5"
+    node-watch: "npm:^0.7.4"
     npm-registry-fetch: "npm:^14.0.3"
     pacote: "npm:^15.0.0"
     postcss: "npm:^8.4.6"
@@ -13387,7 +13484,7 @@ __metadata:
     yargs: "npm:^17.6.2"
   bin:
     openmrs: ./dist/cli.js
-  checksum: 10/7de397c768c0eb54b154ac08a49517097c3ada806bb287708896a2e9503ff515c48d2ebe049507024173a548677abe7199fa8042e1f5dec478ea57821d4b9abe
+  checksum: 10/f06969a2a7d21f3d9708d16f18e69e7c5256c1c9792886850ec26a782edab0032b3da88893e3c94348596aa96ca6b05cccfbf460f0c2bc4a43afe8dbc32f70a7
   languageName: node
   linkType: hard
 
@@ -14566,6 +14663,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-avatar@npm:^5.0.3":
+  version: 5.0.3
+  resolution: "react-avatar@npm:5.0.3"
+  dependencies:
+    is-retina: "npm:^1.0.3"
+    md5: "npm:^2.0.0"
+  peerDependencies:
+    "@babel/runtime": ">=7"
+    core-js-pure: ">=3"
+    prop-types: ^15.0.0 || ^16.0.0
+    react: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
+  checksum: 10/cdbb231d7d19cd3890873b465affe984aa006341c8b6130a670bfe406461665fb8f5607e0c3d7650aa4ec43b96acdad0b572b760e16c2cc41ddc15986aac7590
+  languageName: node
+  linkType: hard
+
 "react-dom@npm:^18.1.0, react-dom@npm:^18.2.0":
   version: 18.2.0
   resolution: "react-dom@npm:18.2.0"
@@ -15683,9 +15795,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"single-spa-react@npm:~5.0.0":
-  version: 5.0.2
-  resolution: "single-spa-react@npm:5.0.2"
+"single-spa-react@npm:^6.0.0":
+  version: 6.0.1
+  resolution: "single-spa-react@npm:6.0.1"
   dependencies:
     browserslist-config-single-spa: "npm:^1.0.1"
   peerDependencies:
@@ -15697,14 +15809,14 @@ __metadata:
       optional: true
     "@types/react-dom":
       optional: true
-  checksum: 10/142f04ffde1cbede0c3b81abe0439b1a87d0a031efa6a4f8c4ae61ffbefe0e9368e32944a63b96e7cd83d2b09ac102278d256fbf4272cf01ad438fdef2295c50
+  checksum: 10/5c75581a0925f031248c184f09dd90200e7518a78642f050ddcc52ff1c59bfb84752a15dd4642511b5388061bf2c594872faeac3469e1f80e2d2c48f013ded8f
   languageName: node
   linkType: hard
 
-"single-spa@npm:^5.9.2":
-  version: 5.9.4
-  resolution: "single-spa@npm:5.9.4"
-  checksum: 10/7b89384063885d3f25bce45996e29928fce9e36ad39bf1189d59b601796bbfe086b40e82d1843a38507c0d9f91f3710a7ddd1f81bf23ec4f24649b2e1ec4f98b
+"single-spa@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "single-spa@npm:6.0.1"
+  checksum: 10/6c192226c0c6d94dbb0d2576c6552ebb9ec01ecad69d069cac47ddd5aa3c2c90e1370765e2d0e36203120a2c48bb7e967e2d6d8a6f9ede4315fd4b9e11cd9e85
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
DEPENDS ON: https://github.com/openmrs/openmrs-esm-core/pull/979

## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

Creates the space for workspace overlays to be rendered on the home page.

Will need to be fixed up once https://github.com/openmrs/openmrs-esm-core/pull/979 is merged.

## Screenshots
![workspace-overlay](https://github.com/openmrs/openmrs-esm-home/assets/1031876/e1991168-3ea2-40db-bbb6-529b7780f5a4)

## Related Issue

https://openmrs.atlassian.net/browse/O3-2724
