### PR TITLE
(fix): add styling to accommodate metric tiles on the home page

### DIFF
--- a/packages/esm-home-app/src/metrics/metrics.component.tsx
+++ b/packages/esm-home-app/src/metrics/metrics.component.tsx
@@ -1,8 +1,9 @@
 import { ExtensionSlot } from '@openmrs/esm-framework';
 import React from 'react';
+import styles from './metrics.scss';
 
 const Metrics: React.FC = () => {
-  return <ExtensionSlot name="home-metrics-tiles-slot" />;
+  return <ExtensionSlot name="home-metrics-tiles-slot" className={styles.metricTilesSlot} />;
 };
 
 export default Metrics;

--- a/packages/esm-home-app/src/metrics/metrics.scss
+++ b/packages/esm-home-app/src/metrics/metrics.scss
@@ -1,0 +1,8 @@
+.metricTilesSlot {
+  display: flex;
+  margin: 0.5rem 0.5rem 0 0.5rem;
+
+  [data-extension-id] {
+    flex-grow: 1;
+  }
+}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
This PR introduces styling to the homepage metric tiles extension slot to accommodate metric tiles loaded as extensions from various esms.
<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
-->
