### PR TITLE
(fix): Wrap page header in t function

### DIFF
--- a/packages/esm-home-app/src/dashboard/home-dashboard.component.tsx
+++ b/packages/esm-home-app/src/dashboard/home-dashboard.component.tsx
@@ -1,14 +1,15 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
 import { useLayoutType, isDesktop, useExtensionStore, ExtensionSlot, WorkspaceContainer } from '@openmrs/esm-framework';
-import DashboardView from './dashboard-view.component';
 import type { DashboardConfig } from '../types/index';
+import DashboardView from './dashboard-view.component';
 import styles from './home-dashboard.scss';
 
 export default function HomeDashboard() {
   const params = useParams();
   const extensionStore = useExtensionStore();
   const layout = useLayoutType();
+
   const ungroupedDashboards =
     extensionStore.slots['homepage-dashboard-slot']?.assignedExtensions
       .map((e) => e.meta)

--- a/packages/esm-home-app/src/index.ts
+++ b/packages/esm-home-app/src/index.ts
@@ -1,10 +1,10 @@
-import { registerBreadcrumbs, defineConfigSchema, getAsyncLifecycle, getSyncLifecycle } from '@openmrs/esm-framework';
+import { defineConfigSchema, getAsyncLifecycle, getSyncLifecycle } from '@openmrs/esm-framework';
 import { createDashboardLink } from './createDashboardLink.component';
 import { dashboardMeta } from './dashboard.meta';
 import { esmHomeSchema } from './openmrs-esm-home-schema';
-import rootComponent from './root.component';
 import homeNavMenuComponent from './side-menu/side-menu.component';
 import homeWidgetDashboardComponent from './home-page-widgets/home-page-widgets.component';
+import rootComponent from './root.component';
 
 const moduleName = '@openmrs/esm-home-app';
 const pageName = 'home';
@@ -30,12 +30,4 @@ export const metrics = getAsyncLifecycle(() => import('./metrics/metrics.compone
 
 export function startupApp() {
   defineConfigSchema(moduleName, esmHomeSchema);
-  // t('home', 'Home');
-
-  registerBreadcrumbs([
-    {
-      path: `${window.spaBase}/${pageName}`,
-      title: () => Promise.resolve(window.i18next.t('home', { defaultValue: 'Home', ns: moduleName })),
-    },
-  ]);
 }

--- a/packages/esm-home-app/src/page-header/page-header.component.tsx
+++ b/packages/esm-home-app/src/page-header/page-header.component.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { PageHeader, HomePictogram } from '@openmrs/esm-framework';
+import { useTranslation } from 'react-i18next';
+import { HomePictogram, PageHeader } from '@openmrs/esm-framework';
 import styles from './page-header.scss';
 
 interface PageHeaderProps {
@@ -7,7 +8,13 @@ interface PageHeaderProps {
 }
 
 const HomePageHeader: React.FC<PageHeaderProps> = ({ dashboardTitle }) => {
-  return <PageHeader illustration={<HomePictogram />} title={dashboardTitle} className={styles.pageHeader} />;
+  const { t } = useTranslation();
+
+  /**
+   * Translation for the home page header
+   * // t('home', 'Home')
+   */
+  return <PageHeader className={styles.pageHeader} illustration={<HomePictogram />} title={t(dashboardTitle)} />;
 };
 
 export default HomePageHeader;


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR wraps the page header title in the `t` function so that it can be translated. I had to add `Home` with the capital `H` to the translation files, as the key `home` doesn't get applied to the text.

## Screenshots
<!-- Required if you are making UI changes. -->
After fix:
<img width="1481" alt="Screenshot 2024-10-29 at 6 16 25 PM" src="https://github.com/user-attachments/assets/54323153-4482-4345-b29c-4c90b63bdbb8">

Before fix:
<img width="1481" alt="Screenshot 2024-10-29 at 6 17 00 PM" src="https://github.com/user-attachments/assets/d8839a59-d696-49ad-9914-155d6f88e9ed">


## Related issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
