### PR TITLE
(chore) Tweak tsconfig lib targets

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,15 +5,8 @@
     "jsx": "react",
     "lib": [
       "dom",
-      "es5",
-      "scripthost",
-      "es2015",
-      "es2015.promise",
-      "es2016.array.include",
-      "es2018",
-      "es2020",
-      "es2021",
-      "es2022"
+      "dom.iterable",
+      "esnext"
     ],
     "module": "esnext",
     "moduleResolution": "node",
@@ -21,11 +14,11 @@
     "paths": {
       "@openmrs/*": ["./node_modules/@openmrs/*"],
       "__mocks__": ["./__mocks__"],
-      "tools": ["./tools"],
+      "tools": ["./tools"]
     },
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strictNullChecks": true,
-    "target": "esnext",
+    "target": "esnext"
   }
 }


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR tweaks the base TypeScript config to allow for better module resolution and better support for modern JavaScript features. Specifically, it removes extraneous lib targets. `[dom, dom.iterable, esnext]` should be sufficient for our setup. 

`es2018`, `es2020`, `es2021`, and `es2022` are cumulative - each one includes all the previous ones. `esnext` includes all current and proposed ECMAScript features.

### Resources

- [TSConfig cheat sheet by Matt Pockock](https://www.totaltypescript.com/tsconfig-cheat-sheet)
- [Official TypeScript TSConfig reference](https://www.typescriptlang.org/tsconfig/#)

## Screenshots
<!-- Required if you are making UI changes. -->

## Related issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
