### PR TITLE
(fix) O3-4253: Update the `name` property of the home dashboard link meta

### DIFF
--- a/packages/esm-home-app/src/routes.json
+++ b/packages/esm-home-app/src/routes.json
@@ -24,7 +24,7 @@
       "slot": "homepage-dashboard-slot",
       "component": "homeWidgetDbLink",
       "meta": {
-        "name": "Home",
+        "name": "home",
         "slot": "home-dashboard-slot",
         "title": ""
       },


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR updates the `name` property of the home page dashboard slot, since the translations are present for the key `home` and not for the key `Home` and hence the respective title on the dashboard metrics wasn't getting translated.

## Screenshots
### Before
<img width="939" alt="image" src="https://github.com/user-attachments/assets/3e559b5a-e6c0-481e-9947-0f0ebb431dfd">

### After
<img width="995" alt="image" src="https://github.com/user-attachments/assets/51e4b1e9-d1b4-4168-bb8c-c12645afba79">


## Related issue
https://issues.openmrs.org/browse/O3-4253

## Other
<!-- Anything not covered above -->
