### PR TITLE
(fix) O3-4159:  Workspace should not cover content on service queues page

### DIFF
--- a/packages/esm-home-app/src/dashboard/home-dashboard.component.tsx
+++ b/packages/esm-home-app/src/dashboard/home-dashboard.component.tsx
@@ -23,7 +23,7 @@ export default function HomeDashboard() {
         {isDesktop(layout) && <ExtensionSlot name="home-sidebar-slot" key={layout} />}
         <DashboardView title={activeDashboard?.name} dashboardSlot={activeDashboard?.slot} />
       </section>
-      <WorkspaceContainer overlay contextKey="home" />
+      <WorkspaceContainer contextKey="home" />
     </div>
   );
 }


### PR DESCRIPTION

# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Previously, the home workspace container rendered as an overlay that covered existing content. Now it renders as a standard workspace that pushes content on the page to the left, matching the behavior in other parts of the application. The key changes this PR makes is removing the `overlay` prop from the workspace container, which effectively turns it into a standard workspace.

## Screenshots

![Screenshot 2024-12-10 at 10 14 52 PM](https://github.com/user-attachments/assets/bdd4f52f-753f-46a7-999e-89391629e6de)

## Related issue

https://openmrs.atlassian.net/browse/O3-4159

## Other
<!-- Anything not covered above -->
