### PR TITLE
(fix) O3-4397: The home dashboard container should have a fixed width

### DIFF
--- a/packages/esm-home-app/src/dashboard/home-dashboard.scss
+++ b/packages/esm-home-app/src/dashboard/home-dashboard.scss
@@ -11,7 +11,11 @@
   margin: 0;
   // Full vertical height minus the primary navigation menu height
   height: calc(100vh - 3rem);
+  // Making space for the left nav menu
   margin-left: 16rem;
+  // Ensure the width of the home page dashboard is fixed
+  // and does not expand based on the width of its children
+  width: calc(100% - 16rem);
   background-color: colors.$gray-10;
 
   & a {


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR fixes the home dashboard container's width to `100% - 16rem(width of side nav)` so that it doesn't expand with increasing children elements.

## Screenshots

### Before
https://github.com/user-attachments/assets/c000276f-a2b5-4942-b24d-777592019798

### After
https://github.com/user-attachments/assets/ff11f61c-bf7f-4504-8b39-b65a46bec146


## Related issue

https://issues.openmrs.org/browse/O3-4397

## Other
None
