### PR TITLE
(chore) Bump core tooling

### DIFF
--- a/packages/esm-home-app/package.json
+++ b/packages/esm-home-app/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/openmrs/openmrs-esm-home/issues"
   },
   "peerDependencies": {
-    "@openmrs/esm-framework": "5.x",
+    "@openmrs/esm-framework": "6.x",
     "react": "18.x",
     "react-i18next": "11.x",
     "react-router-dom": "6.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3168,9 +3168,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openmrs/esm-api@npm:6.1.1-pre.2721":
-  version: 6.1.1-pre.2721
-  resolution: "@openmrs/esm-api@npm:6.1.1-pre.2721"
+"@openmrs/esm-api@npm:6.1.1-pre.2729":
+  version: 6.1.1-pre.2729
+  resolution: "@openmrs/esm-api@npm:6.1.1-pre.2729"
   dependencies:
     "@types/fhir": "npm:0.0.31"
     lodash-es: "npm:^4.17.21"
@@ -3179,17 +3179,17 @@ __metadata:
     "@openmrs/esm-error-handling": 6.x
     "@openmrs/esm-navigation": 6.x
     "@openmrs/esm-offline": 6.x
-  checksum: 10/ea47bfcb247f0ebaacd6aae4b822974cdf20039b8ac1b785f8742985454fb6d0c30e7ef3f3937f0f885755a8cacdcc166bea2e2eee8c51f1a3bc46e7a1f0bd94
+  checksum: 10/83a7a951ec2012ef752bbcdef023de9a4643b77385d3561b428c63104e72e9932022d9c66dc0033f6834c28469dd21d434295d263465ac149f0f6394df8f287c
   languageName: node
   linkType: hard
 
-"@openmrs/esm-app-shell@npm:6.1.1-pre.2721":
-  version: 6.1.1-pre.2721
-  resolution: "@openmrs/esm-app-shell@npm:6.1.1-pre.2721"
+"@openmrs/esm-app-shell@npm:6.1.1-pre.2729":
+  version: 6.1.1-pre.2729
+  resolution: "@openmrs/esm-app-shell@npm:6.1.1-pre.2729"
   dependencies:
     "@carbon/react": "npm:~1.37.0"
-    "@openmrs/esm-framework": "npm:6.1.1-pre.2721"
-    "@openmrs/esm-styleguide": "npm:6.1.1-pre.2721"
+    "@openmrs/esm-framework": "npm:6.1.1-pre.2729"
+    "@openmrs/esm-styleguide": "npm:6.1.1-pre.2729"
     dayjs: "npm:^1.10.4"
     dexie: "npm:^3.0.3"
     html-webpack-plugin: "npm:^5.5.0"
@@ -3214,13 +3214,13 @@ __metadata:
     workbox-strategies: "npm:^6.1.5"
     workbox-webpack-plugin: "npm:^6.1.5"
     workbox-window: "npm:^6.1.5"
-  checksum: 10/1d5d7c817f49661f497b01fcd6298f68c2a1edbf528d74c28d4a9529681c1b60feb2339824fc48edb044e408fb8a6119914552d4ecd529bf02c7ef7ad51f818f
+  checksum: 10/ead5a8010075097dd3c4b3fd52563810bc2b369d35830abf233edfbc806645c321ffb86e81dd17234a16ff87ae3e3f48c48f9fc7757a5c731be9834ae7d833c3
   languageName: node
   linkType: hard
 
-"@openmrs/esm-config@npm:6.1.1-pre.2721":
-  version: 6.1.1-pre.2721
-  resolution: "@openmrs/esm-config@npm:6.1.1-pre.2721"
+"@openmrs/esm-config@npm:6.1.1-pre.2729":
+  version: 6.1.1-pre.2729
+  resolution: "@openmrs/esm-config@npm:6.1.1-pre.2729"
   dependencies:
     ramda: "npm:^0.26.1"
   peerDependencies:
@@ -3228,44 +3228,44 @@ __metadata:
     "@openmrs/esm-state": 6.x
     "@openmrs/esm-utils": 6.x
     single-spa: 6.x
-  checksum: 10/41f7408590e128d990797996d0ad42e6ba3d2fc2e4450cc5cd5801cbaab6e7feac2decac68314862238bf5964cf9731c5e27358bd4dc12f3ea055ee8267cbaee
+  checksum: 10/c1318ef37fd12959a152a420530093ff8c840cf23c5fb8fdec830aae65da820f2200b9294f2e5939ea0a13979cc3c028588b6f1d72defc4525cb6a891219b867
   languageName: node
   linkType: hard
 
-"@openmrs/esm-context@npm:6.1.1-pre.2721":
-  version: 6.1.1-pre.2721
-  resolution: "@openmrs/esm-context@npm:6.1.1-pre.2721"
+"@openmrs/esm-context@npm:6.1.1-pre.2729":
+  version: 6.1.1-pre.2729
+  resolution: "@openmrs/esm-context@npm:6.1.1-pre.2729"
   dependencies:
     immer: "npm:^10.0.4"
   peerDependencies:
     "@openmrs/esm-globals": 6.x
     "@openmrs/esm-state": 6.x
-  checksum: 10/5f12e3ffbae935fc14c5822fd526bfad293f234b26cf4606fcf646c94a55df7ef6c0fe578b12a616a87ce7c85aeb987628bbed9673a8c8d7c25b4596676e7ebb
+  checksum: 10/637014c69b688e64b370e2210845bf0ef51ea2fe8359a931dc1f1af006042cb118a6976bb0826266ec1dc4001878efdb2fbf3c34d2a1a56d03b3feece846c653
   languageName: node
   linkType: hard
 
-"@openmrs/esm-dynamic-loading@npm:6.1.1-pre.2721":
-  version: 6.1.1-pre.2721
-  resolution: "@openmrs/esm-dynamic-loading@npm:6.1.1-pre.2721"
+"@openmrs/esm-dynamic-loading@npm:6.1.1-pre.2729":
+  version: 6.1.1-pre.2729
+  resolution: "@openmrs/esm-dynamic-loading@npm:6.1.1-pre.2729"
   peerDependencies:
     "@openmrs/esm-globals": 6.x
     "@openmrs/esm-translations": 6.x
-  checksum: 10/5777c4bad58fc515ef40e87ef44ad3c8cf685f62ff1efdeee3ecc805907cf214dfd0996d577cb9e2f13229973507adf229180d1c4bf0da8d73341b83fcff908a
+  checksum: 10/60e85b80615c26aa13dfca03bebe52fb544c8b660604a8744e86a7ccf6ea9bcf86492d5a7de3b3ab6457e098c7f0aee191f958cc1bc3d3af9e051b5120420e9e
   languageName: node
   linkType: hard
 
-"@openmrs/esm-error-handling@npm:6.1.1-pre.2721":
-  version: 6.1.1-pre.2721
-  resolution: "@openmrs/esm-error-handling@npm:6.1.1-pre.2721"
+"@openmrs/esm-error-handling@npm:6.1.1-pre.2729":
+  version: 6.1.1-pre.2729
+  resolution: "@openmrs/esm-error-handling@npm:6.1.1-pre.2729"
   peerDependencies:
     "@openmrs/esm-globals": 6.x
-  checksum: 10/6883a4382fae10e207510e455d67665cf90ec126bf7873456a2b351f3f9020284c783aec83e0c93d128722ea6c0724d2b07fe699ffc45860914f85c39eceef6e
+  checksum: 10/0a82cb163050de2a1fbe206e302c6997341d8c8d1a04b3aee61d9e2d8e3e60c1ae5d8ab0713e7877dec485f7e8eb9b1e42b2d85f757d9a6616da4c1a8a23304f
   languageName: node
   linkType: hard
 
-"@openmrs/esm-expression-evaluator@npm:6.1.1-pre.2721":
-  version: 6.1.1-pre.2721
-  resolution: "@openmrs/esm-expression-evaluator@npm:6.1.1-pre.2721"
+"@openmrs/esm-expression-evaluator@npm:6.1.1-pre.2729":
+  version: 6.1.1-pre.2729
+  resolution: "@openmrs/esm-expression-evaluator@npm:6.1.1-pre.2729"
   dependencies:
     "@jsep-plugin/arrow": "npm:^1.0.5"
     "@jsep-plugin/new": "npm:^1.0.3"
@@ -3274,13 +3274,13 @@ __metadata:
     "@jsep-plugin/template": "npm:^1.0.4"
     "@jsep-plugin/ternary": "npm:^1.1.3"
     jsep: "npm:^1.3.9"
-  checksum: 10/8a8eca5af0393744e878ce87d3ce81d21c6923cf85e2e6e975946d04c5ebc8115ced38112b895d4f3340cfeaace770e5d5fba3ae7f4c107fdd5598810405edc1
+  checksum: 10/7809659a57032b9fef0714f09d295285a9c94c445bd1a9565781ee5bc053fb550c9b3ba8c9d392d1b7e9f9178e7863cf072f3894be1d2b147197518e33decf03
   languageName: node
   linkType: hard
 
-"@openmrs/esm-extensions@npm:6.1.1-pre.2721":
-  version: 6.1.1-pre.2721
-  resolution: "@openmrs/esm-extensions@npm:6.1.1-pre.2721"
+"@openmrs/esm-extensions@npm:6.1.1-pre.2729":
+  version: 6.1.1-pre.2729
+  resolution: "@openmrs/esm-extensions@npm:6.1.1-pre.2729"
   dependencies:
     lodash-es: "npm:^4.17.21"
   peerDependencies:
@@ -3291,44 +3291,44 @@ __metadata:
     "@openmrs/esm-state": 6.x
     "@openmrs/esm-utils": 6.x
     single-spa: 6.x
-  checksum: 10/c5965ce508739e7f72de4c61865fdac19968893ed9c19ecc5b5104a0ab3de5b741fa3160eeea4396584981de7305408509970e539b066d2ba895f0fc75eeda60
+  checksum: 10/a8f0824e41c15febc01661989bef6a9400912ea03c347c26f359e31d90e637a60d53f512b5cfc0010d0dd6e7fba84c37483340fe6037339cefccf6b62eccbf01
   languageName: node
   linkType: hard
 
-"@openmrs/esm-feature-flags@npm:6.1.1-pre.2721":
-  version: 6.1.1-pre.2721
-  resolution: "@openmrs/esm-feature-flags@npm:6.1.1-pre.2721"
+"@openmrs/esm-feature-flags@npm:6.1.1-pre.2729":
+  version: 6.1.1-pre.2729
+  resolution: "@openmrs/esm-feature-flags@npm:6.1.1-pre.2729"
   dependencies:
     ramda: "npm:^0.26.1"
   peerDependencies:
     "@openmrs/esm-globals": 6.x
     "@openmrs/esm-state": 6.x
     single-spa: 6.x
-  checksum: 10/cc850f34426b660dd642f2074c86ecafca7bd63895d2865a20a5f0bbeb943c48a11fb20f83430b5c5fc90309b6217af65076f9ae8e1ba6816e85e367ca0e315a
+  checksum: 10/76cf666ffafcc66c1697dc13a8a63494d02d46aeb13094a8c70025f05d3dfb5ac61b974cd3a39c1c7753a0a5ffab566d28aa12d64aae035638408fbbf183b31d
   languageName: node
   linkType: hard
 
-"@openmrs/esm-framework@npm:6.1.1-pre.2721, @openmrs/esm-framework@npm:next":
-  version: 6.1.1-pre.2721
-  resolution: "@openmrs/esm-framework@npm:6.1.1-pre.2721"
+"@openmrs/esm-framework@npm:6.1.1-pre.2729, @openmrs/esm-framework@npm:next":
+  version: 6.1.1-pre.2729
+  resolution: "@openmrs/esm-framework@npm:6.1.1-pre.2729"
   dependencies:
-    "@openmrs/esm-api": "npm:6.1.1-pre.2721"
-    "@openmrs/esm-config": "npm:6.1.1-pre.2721"
-    "@openmrs/esm-context": "npm:6.1.1-pre.2721"
-    "@openmrs/esm-dynamic-loading": "npm:6.1.1-pre.2721"
-    "@openmrs/esm-error-handling": "npm:6.1.1-pre.2721"
-    "@openmrs/esm-expression-evaluator": "npm:6.1.1-pre.2721"
-    "@openmrs/esm-extensions": "npm:6.1.1-pre.2721"
-    "@openmrs/esm-feature-flags": "npm:6.1.1-pre.2721"
-    "@openmrs/esm-globals": "npm:6.1.1-pre.2721"
-    "@openmrs/esm-navigation": "npm:6.1.1-pre.2721"
-    "@openmrs/esm-offline": "npm:6.1.1-pre.2721"
-    "@openmrs/esm-react-utils": "npm:6.1.1-pre.2721"
-    "@openmrs/esm-routes": "npm:6.1.1-pre.2721"
-    "@openmrs/esm-state": "npm:6.1.1-pre.2721"
-    "@openmrs/esm-styleguide": "npm:6.1.1-pre.2721"
-    "@openmrs/esm-translations": "npm:6.1.1-pre.2721"
-    "@openmrs/esm-utils": "npm:6.1.1-pre.2721"
+    "@openmrs/esm-api": "npm:6.1.1-pre.2729"
+    "@openmrs/esm-config": "npm:6.1.1-pre.2729"
+    "@openmrs/esm-context": "npm:6.1.1-pre.2729"
+    "@openmrs/esm-dynamic-loading": "npm:6.1.1-pre.2729"
+    "@openmrs/esm-error-handling": "npm:6.1.1-pre.2729"
+    "@openmrs/esm-expression-evaluator": "npm:6.1.1-pre.2729"
+    "@openmrs/esm-extensions": "npm:6.1.1-pre.2729"
+    "@openmrs/esm-feature-flags": "npm:6.1.1-pre.2729"
+    "@openmrs/esm-globals": "npm:6.1.1-pre.2729"
+    "@openmrs/esm-navigation": "npm:6.1.1-pre.2729"
+    "@openmrs/esm-offline": "npm:6.1.1-pre.2729"
+    "@openmrs/esm-react-utils": "npm:6.1.1-pre.2729"
+    "@openmrs/esm-routes": "npm:6.1.1-pre.2729"
+    "@openmrs/esm-state": "npm:6.1.1-pre.2729"
+    "@openmrs/esm-styleguide": "npm:6.1.1-pre.2729"
+    "@openmrs/esm-translations": "npm:6.1.1-pre.2729"
+    "@openmrs/esm-utils": "npm:6.1.1-pre.2729"
     dayjs: "npm:^1.10.7"
   peerDependencies:
     dayjs: 1.x
@@ -3339,18 +3339,18 @@ __metadata:
     rxjs: 6.x
     single-spa: 6.x
     swr: 2.x
-  checksum: 10/616318181327f088d9c1d1938b37f450f23654ce1debaaa1d2f6ce843f20b796ab9835219ee59bf45eede44d87b90130a170bb32a3db4b60103dfceb5702f9eb
+  checksum: 10/522c1879b4c65366dfa8d5039c414413a8660fec5432c0fc671030c065880b6a7450e0edacc0d59de37277fbdd2664aa091784eb9cf3e75097dc4a1067a1468c
   languageName: node
   linkType: hard
 
-"@openmrs/esm-globals@npm:6.1.1-pre.2721":
-  version: 6.1.1-pre.2721
-  resolution: "@openmrs/esm-globals@npm:6.1.1-pre.2721"
+"@openmrs/esm-globals@npm:6.1.1-pre.2729":
+  version: 6.1.1-pre.2729
+  resolution: "@openmrs/esm-globals@npm:6.1.1-pre.2729"
   dependencies:
     "@types/fhir": "npm:0.0.31"
   peerDependencies:
     single-spa: 6.x
-  checksum: 10/544a185374e42945a112a5b31181e2a4cb881324185c7e1617ee28ef71a0ea215c10565475ddc63c54a344916e2b842e10215731eb2d4d822b1c3609159ff6e4
+  checksum: 10/221db2e9dbc6e930d744b8f655487628a59c9bf714bd5330ceaff4082648213a989e3507e32dae630a8ed543d0064db43f27512a14974b92fbefd62373454916
   languageName: node
   linkType: hard
 
@@ -3358,7 +3358,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@openmrs/esm-home-app@workspace:packages/esm-home-app"
   peerDependencies:
-    "@openmrs/esm-framework": 5.x
+    "@openmrs/esm-framework": 6.x
     react: 18.x
     react-i18next: 11.x
     react-router-dom: 6.x
@@ -3417,20 +3417,20 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-navigation@npm:6.1.1-pre.2721":
-  version: 6.1.1-pre.2721
-  resolution: "@openmrs/esm-navigation@npm:6.1.1-pre.2721"
+"@openmrs/esm-navigation@npm:6.1.1-pre.2729":
+  version: 6.1.1-pre.2729
+  resolution: "@openmrs/esm-navigation@npm:6.1.1-pre.2729"
   dependencies:
     path-to-regexp: "npm:6.1.0"
   peerDependencies:
     "@openmrs/esm-state": 6.x
-  checksum: 10/b93f5949b641c5e68aa06067033f64bc71adb3410e65e4daa3e5e697ac56c18fbd824aec976ff4cee1da7c84ba1fd2314eceaaa77f818f9d267ea85c53e3e063
+  checksum: 10/b8761b16184b3c3d7a43dbad0941450fbcb24df028a02099ddc27a58089aff370c40b1625e47fefdee583e7c0fc0d6d180a58bc878141d99c39b2f70b9eb922f
   languageName: node
   linkType: hard
 
-"@openmrs/esm-offline@npm:6.1.1-pre.2721":
-  version: 6.1.1-pre.2721
-  resolution: "@openmrs/esm-offline@npm:6.1.1-pre.2721"
+"@openmrs/esm-offline@npm:6.1.1-pre.2729":
+  version: 6.1.1-pre.2729
+  resolution: "@openmrs/esm-offline@npm:6.1.1-pre.2729"
   dependencies:
     dexie: "npm:^3.0.3"
     lodash-es: "npm:^4.17.21"
@@ -3441,13 +3441,13 @@ __metadata:
     "@openmrs/esm-globals": 6.x
     "@openmrs/esm-state": 6.x
     rxjs: 6.x
-  checksum: 10/6c6f679b1e5d32d334edb1a3e73e2a5efcc191878335800096a3f3c47fd30be87dd015d99b5cc6473d841c810b29ac9b142e4e83c771cdd4661f4742c6001c24
+  checksum: 10/65af2d2f87735047aa7c48b8adac5f1561d54b3bf416e08ab3fe30f8bff2196076ca4c7a407596487308ace51372066260a7852049a8325c8beaa10ba6d2b2b5
   languageName: node
   linkType: hard
 
-"@openmrs/esm-react-utils@npm:6.1.1-pre.2721":
-  version: 6.1.1-pre.2721
-  resolution: "@openmrs/esm-react-utils@npm:6.1.1-pre.2721"
+"@openmrs/esm-react-utils@npm:6.1.1-pre.2729":
+  version: 6.1.1-pre.2729
+  resolution: "@openmrs/esm-react-utils@npm:6.1.1-pre.2729"
   dependencies:
     lodash-es: "npm:^4.17.21"
     single-spa-react: "npm:^6.0.2"
@@ -3468,13 +3468,13 @@ __metadata:
     react-i18next: 11.x
     rxjs: 6.x
     swr: 2.x
-  checksum: 10/701182db750ad7041410340c58e904077856c5f52081d448b49bdefa0350b50320b9289de37159300d39b5978209ec5a6d5551da5b1319584be2b8a46dd4bba4
+  checksum: 10/54b089a64b421037f6746e87eb3ae399a23961dda533146abb6c0dd96acf37c1e0afcca289514322beae6e5f8b111e6cbc04000fd58150ba5d0ff0748a503622
   languageName: node
   linkType: hard
 
-"@openmrs/esm-routes@npm:6.1.1-pre.2721":
-  version: 6.1.1-pre.2721
-  resolution: "@openmrs/esm-routes@npm:6.1.1-pre.2721"
+"@openmrs/esm-routes@npm:6.1.1-pre.2729":
+  version: 6.1.1-pre.2729
+  resolution: "@openmrs/esm-routes@npm:6.1.1-pre.2729"
   peerDependencies:
     "@openmrs/esm-config": 6.x
     "@openmrs/esm-dynamic-loading": 6.x
@@ -3483,25 +3483,25 @@ __metadata:
     "@openmrs/esm-globals": 6.x
     "@openmrs/esm-utils": 6.x
     single-spa: 6.x
-  checksum: 10/d0df073ca47fadac428a97da5353affd76e3c745bb0665905c5ffb47457d69cea337598dceb14894e545f0343ad0430f05b6819fde4e497db294a87a78fca3e9
+  checksum: 10/6c17d91c5d0109790cbc06b715926d9f69e02aa81c16be100ccb0a0ed742badf12b1926ccde729178cf83803f1f3415f66ac6341b469ae463cd6a1fc3e88e290
   languageName: node
   linkType: hard
 
-"@openmrs/esm-state@npm:6.1.1-pre.2721":
-  version: 6.1.1-pre.2721
-  resolution: "@openmrs/esm-state@npm:6.1.1-pre.2721"
+"@openmrs/esm-state@npm:6.1.1-pre.2729":
+  version: 6.1.1-pre.2729
+  resolution: "@openmrs/esm-state@npm:6.1.1-pre.2729"
   dependencies:
     zustand: "npm:^4.5.5"
   peerDependencies:
     "@openmrs/esm-globals": 6.x
     "@openmrs/esm-utils": 6.x
-  checksum: 10/8d4467b0fa54b3e643d38f7867cc3d5477a21ff1f98c221eda300fa3dc51bff993de4fdb343e30d459b73377c1116c57002b1d72f673beb5bb8c83e910dafa0a
+  checksum: 10/b956b6fde85e7fad30eae7d95056fcc8880085cbb2d28c16ffcebe0afb985413927afa1bd6278555f405977917d2d5981b687ba3d87902ebbfbf6a0b54b9541b
   languageName: node
   linkType: hard
 
-"@openmrs/esm-styleguide@npm:6.1.1-pre.2721":
-  version: 6.1.1-pre.2721
-  resolution: "@openmrs/esm-styleguide@npm:6.1.1-pre.2721"
+"@openmrs/esm-styleguide@npm:6.1.1-pre.2729":
+  version: 6.1.1-pre.2729
+  resolution: "@openmrs/esm-styleguide@npm:6.1.1-pre.2729"
   dependencies:
     "@carbon/charts": "npm:^1.12.0"
     "@carbon/react": "npm:~1.37.0"
@@ -3525,24 +3525,24 @@ __metadata:
     react-dom: 18.x
     react-i18next: 11.x
     rxjs: 6.x
-  checksum: 10/23f225b13a6b26e6724acd06467c324e2ea3016f873686a6642ba9c9bbf9eb7a75bd14f0d880f49b3be18d8bbc112a37f4117151c4d68632127e16234d3a3ebb
+  checksum: 10/535f0ab78ccdb96d508f6afc04c86b4176838c542f41d7c23e30a4799fe3307efef36956aa80f8c26c2dac9a13c1c4bc5fe1ab52ae1b9fcf8e44d65669fd2359
   languageName: node
   linkType: hard
 
-"@openmrs/esm-translations@npm:6.1.1-pre.2721":
-  version: 6.1.1-pre.2721
-  resolution: "@openmrs/esm-translations@npm:6.1.1-pre.2721"
+"@openmrs/esm-translations@npm:6.1.1-pre.2729":
+  version: 6.1.1-pre.2729
+  resolution: "@openmrs/esm-translations@npm:6.1.1-pre.2729"
   dependencies:
     i18next: "npm:21.10.0"
   peerDependencies:
     i18next: 21.x
-  checksum: 10/1beb6ace2732e813b77da50901ec100ee3dcac5a5028abc04cadb8e5dcc87055b6420b97902b3706feaae146df8e5d50cb858f2b3b71ba52ceb87c5b8a2a9a74
+  checksum: 10/255dedcba8278993cda825e4ba3d5a5d8c489729466eb16a94f8e2e00a5e318a19f3f87fabcb62ce82d9bbf1c9d5d6c4f2efa30bf63fae9f26ed183d9beddd25
   languageName: node
   linkType: hard
 
-"@openmrs/esm-utils@npm:6.1.1-pre.2721":
-  version: 6.1.1-pre.2721
-  resolution: "@openmrs/esm-utils@npm:6.1.1-pre.2721"
+"@openmrs/esm-utils@npm:6.1.1-pre.2729":
+  version: 6.1.1-pre.2729
+  resolution: "@openmrs/esm-utils@npm:6.1.1-pre.2729"
   dependencies:
     "@formatjs/intl-durationformat": "npm:^0.2.4"
     "@internationalized/date": "npm:^3.7.0"
@@ -3552,13 +3552,13 @@ __metadata:
     dayjs: 1.x
     i18next: 21.x
     rxjs: 6.x
-  checksum: 10/95f057f5e29e5f2b4b7ebeca26a96dae1b83d3f698af1e53e2740bd6e61c5b43fc5d33929748442f7ecb35d481aaac8172fb23c26d3e47e066878279366a7ad6
+  checksum: 10/002dd85e829e21bdbbaf097d01657a438c83ff4755a5c86b9fd3c3b5eee6616a08df712b290d98811d016c6f403f4de35915822e482cdb069d428779780b2027
   languageName: node
   linkType: hard
 
-"@openmrs/webpack-config@npm:6.1.1-pre.2721":
-  version: 6.1.1-pre.2721
-  resolution: "@openmrs/webpack-config@npm:6.1.1-pre.2721"
+"@openmrs/webpack-config@npm:6.1.1-pre.2729":
+  version: 6.1.1-pre.2729
+  resolution: "@openmrs/webpack-config@npm:6.1.1-pre.2729"
   dependencies:
     "@swc/core": "npm:^1.3.58"
     clean-webpack-plugin: "npm:^4.0.0"
@@ -3576,7 +3576,7 @@ __metadata:
     webpack-stats-plugin: "npm:^1.0.3"
   peerDependencies:
     webpack: 5.x
-  checksum: 10/fb5d5bf82170223b1c7294e5e8ee2318f21a6bf7c5a6dd89c8446a37cfee783abb0a2f7f7e24da57864c933f648eb119b971e993eff20095adaff2d6a6c33920
+  checksum: 10/73564d915e2d2f88a332d7b277faefd449ef5aaf4fbae96cfcfc5a6463554c4e154041e89470ba5f22ea822f079df2e75afc2a8f820ac9fcf3616296e90cf410
   languageName: node
   linkType: hard
 
@@ -14586,11 +14586,11 @@ __metadata:
   linkType: hard
 
 "openmrs@npm:next":
-  version: 6.1.1-pre.2721
-  resolution: "openmrs@npm:6.1.1-pre.2721"
+  version: 6.1.1-pre.2729
+  resolution: "openmrs@npm:6.1.1-pre.2729"
   dependencies:
-    "@openmrs/esm-app-shell": "npm:6.1.1-pre.2721"
-    "@openmrs/webpack-config": "npm:6.1.1-pre.2721"
+    "@openmrs/esm-app-shell": "npm:6.1.1-pre.2729"
+    "@openmrs/webpack-config": "npm:6.1.1-pre.2729"
     "@pnpm/npm-conf": "npm:^2.1.0"
     "@swc/core": "npm:^1.3.58"
     autoprefixer: "npm:^10.4.20"
@@ -14629,7 +14629,7 @@ __metadata:
     yargs: "npm:^17.6.2"
   bin:
     openmrs: ./dist/cli.js
-  checksum: 10/02924fe4bd825004a303f400a57334d585d5670c7a177c691760c7cbacf011f781de5dec87ce03f59b6c55bcd78c93750e6972a1098a0190ad80da4ea375f295
+  checksum: 10/aaa8d3975e75aecb1042922c4354c3c82fb1798b2874450e41e16409f1244bc326a91c9201715b1e450beb3768cf038c0a48c548d74c8108a4ebe9cbbe8b88cf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Bumps `openmrs` and `@openmrs/esm-framework` to the next tagged versions. More specifically, it fixes an issue where the home app is running on the wrong version of the framework.

## Screenshots

Fixes this error in the browser devtools console on test3.openmrs.org:

![CleanShot 2025-02-26 at 10  15 33@2x](https://github.com/user-attachments/assets/528ce93d-375b-4af2-94b8-d75b45fa2a4e)

## Related issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
